### PR TITLE
Add JWK set URI configuration for OAuth2 resource server

### DIFF
--- a/infrastructure/src/main/resources/application.yml
+++ b/infrastructure/src/main/resources/application.yml
@@ -20,6 +20,7 @@ spring:
     oauth2:
       resourceserver:
         jwt:
+          jwk-set-uri: ${keycloak.host}/realms/${keycloak.realm}/protocol/openid-connect/certs
           issuer-uri: ${keycloak.host}/realms/${keycloak.realm}
   datasource:
     driver-class-name: org.postgresql.Driver


### PR DESCRIPTION
Este pull request inclui uma pequena alteração no arquivo `infrastructure/src/main/resources/application.yml`. A alteração adiciona uma nova propriedade de configuração para o servidor de recursos JWT.

* Adicionada a propriedade `jwk-set-uri` sob `spring.oauth2.resourceserver.jwt` para especificar a URI para o conjunto de chaves JSON Web.