### PR TITLE
feat: add forward-headers-strategy configuration to environment files…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 SPRING_PROFILES_ACTIVE=env
 
 SERVER_PORT=8080
+FORWARD_HEADERS_STRATEGY=framework #none for no proxy, framework for Spring Cloud Gateway, native for native proxy
 REQUEST_TIMEOUT=60000
 
 KEYCLOAK_HOST=http://localhost:8090

--- a/infrastructure/src/main/resources/application-env.yml
+++ b/infrastructure/src/main/resources/application-env.yml
@@ -1,5 +1,6 @@
 server:
   port: ${SERVER_PORT}
+  forward-headers-strategy: ${FORWARD_HEADERS_STRATEGY:none}
 
 keycloak:
   realm: ${KEYCLOAK_REALM}

--- a/infrastructure/src/main/resources/application.yml
+++ b/infrastructure/src/main/resources/application.yml
@@ -1,5 +1,6 @@
 server:
   port: 80
+  forward-headers-strategy: none
   servlet:
     context-path: /api
   compression:


### PR DESCRIPTION
This pull request introduces a new configuration option for handling forwarded headers in the application. The changes add support for specifying a forwarding strategy, which can be set to `none`, `framework`, or `native`. This enhances flexibility in proxy handling and ensures compatibility with different deployment setups.

### Configuration Updates:

* [`.env.example`](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cR4): Added a new environment variable `FORWARD_HEADERS_STRATEGY` with a description of its possible values (`none`, `framework`, `native`).

* [`infrastructure/src/main/resources/application-env.yml`](diffhunk://#diff-ee891634d2fbd850a3417e7e9fc630b8838dc104104440d86ba4b41bf3ff69e1R3): Introduced the `forward-headers-strategy` configuration, which reads its value from the `FORWARD_HEADERS_STRATEGY` environment variable, defaulting to `none` if not specified.

* [`infrastructure/src/main/resources/application.yml`](diffhunk://#diff-82089b863cabb57e614254a157dd99db0dbf6f799a36f75075190554168311f9R3): Set the default `forward-headers-strategy` to `none` in the base configuration file.… for proxy support