### PR TITLE
fix: rename allowedOriginsPatterns to allowedOrigins in CORS configur…

### DIFF
--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/configuration/properties/cors/CorsConfigurationProperties.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/configuration/properties/cors/CorsConfigurationProperties.java
@@ -5,7 +5,7 @@ import java.util.List;
 public class CorsConfigurationProperties {
 
     private String pattern;
-    private List<String> allowedOriginsPatterns;
+    private List<String> allowedOrigins;
     private List<String> allowedMethods;
     private List<String> allowedHeaders;
     private boolean allowCredentials;
@@ -18,12 +18,12 @@ public class CorsConfigurationProperties {
         this.pattern = pattern;
     }
 
-    public List<String> getAllowedOriginsPatterns() {
-        return allowedOriginsPatterns;
+    public List<String> getAllowedOrigins() {
+        return allowedOrigins;
     }
 
-    public void setAllowedOriginsPatterns(List<String> allowedOriginsPatterns) {
-        this.allowedOriginsPatterns = allowedOriginsPatterns;
+    public void setAllowedOrigins(List<String> allowedOriginsPatterns) {
+        this.allowedOrigins = allowedOriginsPatterns;
     }
 
     public List<String> getAllowedMethods() {

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/configuration/security/SecurityConfig.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/configuration/security/SecurityConfig.java
@@ -64,7 +64,7 @@ public class SecurityConfig {
         source.registerCorsConfiguration(
                 corsProperties.getPattern(),
                 corsConfiguration(
-                        corsProperties.getAllowedOriginsPatterns(),
+                        corsProperties.getAllowedOrigins(),
                         corsProperties.getAllowedMethods(),
                         corsProperties.getAllowedHeaders(),
                         corsProperties.isAllowCredentials()));


### PR DESCRIPTION
This pull request updates the CORS configuration in the `infrastructure` module to simplify property naming and improve clarity. The most significant changes involve renaming `allowedOriginsPatterns` to `allowedOrigins` in the `CorsConfigurationProperties` class and updating related methods and usages accordingly.

### CORS Configuration Updates:

* **Renamed property in `CorsConfigurationProperties`:**
  - Changed `allowedOriginsPatterns` to `allowedOrigins` for better clarity and consistency. This includes updates to the property declaration, getter, and setter methods in `CorsConfigurationProperties`. (`[[1]](diffhunk://#diff-e83bcb29de835da42a10772c6a5fbe1150615504c4868a8f1a35af2e3741e7e9L8-R8)`, `[[2]](diffhunk://#diff-e83bcb29de835da42a10772c6a5fbe1150615504c4868a8f1a35af2e3741e7e9L21-R26)`)

* **Updated usage in `SecurityConfig`:**
  - Modified the `corsConfigurationSource` method in `SecurityConfig` to use `corsProperties.getAllowedOrigins()` instead of `corsProperties.getAllowedOriginsPatterns()`. (`[infrastructure/src/main/java/com/callv2/drive/infrastructure/configuration/security/SecurityConfig.javaL67-R67](diffhunk://#diff-3cb27b704bdcb86129bb28719f587cae9c240aa255e6f10e2c018e568938ba78L67-R67)`)