### PR TITLE
fix: file creation validation and error handling in DefaultCreateFile…

### DIFF
--- a/application/src/main/java/com/callv2/drive/application/file/create/DefaultCreateFileUseCase.java
+++ b/application/src/main/java/com/callv2/drive/application/file/create/DefaultCreateFileUseCase.java
@@ -59,14 +59,24 @@ public class DefaultCreateFileUseCase extends CreateFileUseCase {
 
         if (actualUsedQuota + input.size() > owner.getQuota().sizeInBytes())
             throw QuotaExceededException.with("Quota exceeded",
-                    new Error("You have exceeded your actual quota of " + owner.getQuota().sizeInBytes() + " bytes"));
+                    Error.with("You have exceeded your actual quota of " + owner.getQuota().sizeInBytes() + " bytes"));
 
         final FolderID folderId = folderGateway
                 .findById(FolderID.of(input.folderId()))
                 .map(Folder::getId)
                 .orElseThrow(() -> NotFoundException.with(Folder.class, input.folderId().toString()));
 
+        final Notification notification = Notification.create();
+
         final FileName fileName = FileName.of(input.name());
+        fileName.validate(notification);
+        if (notification.hasError())
+            throw ValidationException.with("Could not create Aggregate File", notification);
+
+        final List<File> filesOnSameFolder = fileGateway.findByFolder(folderId);
+        if (filesOnSameFolder.stream().map(File::getName).anyMatch(fileName::equals))
+            throw ValidationException.with("Could not create Aggregate File",
+                    Error.with("File with same name already exists on this folder"));
 
         final String randomContentName = UUID.randomUUID().toString();
         final String contentLocation = storeContentFile(randomContentName, input.content());
@@ -75,13 +85,7 @@ public class DefaultCreateFileUseCase extends CreateFileUseCase {
 
         final Content content = Content.of(contentLocation, contentType, contentSize);
 
-        final Notification notification = Notification.create();
         final File file = notification.valdiate(() -> File.create(ownerId, folderId, fileName, content));
-
-        List<File> filesOnSameFolder = fileGateway.findByFolder(folderId);
-        if (filesOnSameFolder.stream().map(File::getName).anyMatch(fileName::equals))
-            notification.append(Error.with("File with same name already exists on this folder"));
-
         if (notification.hasError())
             throw ValidationException.with("Could not create Aggregate File", notification);
 

--- a/application/src/test/java/com/callv2/drive/application/file/create/DefaultCreateFileUseCaseTest.java
+++ b/application/src/test/java/com/callv2/drive/application/file/create/DefaultCreateFileUseCaseTest.java
@@ -25,6 +25,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.callv2.drive.domain.exception.InternalErrorException;
 import com.callv2.drive.domain.exception.NotFoundException;
+import com.callv2.drive.domain.exception.QuotaExceededException;
 import com.callv2.drive.domain.exception.ValidationException;
 import com.callv2.drive.domain.file.Content;
 import com.callv2.drive.domain.file.File;
@@ -32,6 +33,7 @@ import com.callv2.drive.domain.file.FileGateway;
 import com.callv2.drive.domain.file.FileName;
 import com.callv2.drive.domain.folder.Folder;
 import com.callv2.drive.domain.folder.FolderGateway;
+import com.callv2.drive.domain.folder.FolderID;
 import com.callv2.drive.domain.member.Member;
 import com.callv2.drive.domain.member.MemberGateway;
 import com.callv2.drive.domain.member.MemberID;
@@ -127,7 +129,7 @@ public class DefaultCreateFileUseCaseTest {
     }
 
     @Test
-    void givenAnInvalidId_whenCallsExecute_thenShouldThrowNotFoundException() {
+    void givenAnInvalidFolderId_whenCallsExecute_thenShouldThrowNotFoundException() {
 
         final var owner = Member.create(MemberID.of("owner"))
                 .requestQuota(Quota.of(1, QuotaUnit.GIGABYTE))
@@ -178,6 +180,48 @@ public class DefaultCreateFileUseCaseTest {
     }
 
     @Test
+    void givenAnInvalidMemberId_whenCallsExecute_thenShouldThrowNotFoundException() {
+
+        final var expectedOwnerId = MemberID.of("inexistent");
+        final var expectedFolderId = FolderID.unique();
+
+        final var expectedFileName = FileName.of("file");
+        final var expectedContentType = "image/jpeg";
+        final var contentBytes = "content".getBytes();
+
+        final var expectedContent = new ByteArrayInputStream(contentBytes);
+        final var expectedContentSize = (long) contentBytes.length;
+
+        final var expectedExceptionMessage = "Member with id '%s' not found"
+                .formatted(expectedOwnerId.getValue());
+
+        when(memberGateway.findById(any()))
+                .thenReturn(Optional.empty());
+
+        final var input = CreateFileInput.of(
+                expectedOwnerId.getValue(),
+                expectedFolderId.getValue(),
+                expectedFileName.value(),
+                expectedContentType,
+                expectedContent,
+                expectedContentSize);
+
+        final var actualException = assertThrows(NotFoundException.class, () -> useCase.execute(input));
+
+        assertEquals(expectedExceptionMessage, actualException.getMessage());
+
+        verify(memberGateway, times(1)).findById(any());
+        verify(memberGateway, times(1)).findById(eq(expectedOwnerId));
+        verify(folderGateway, times(0)).findById(any());
+        verify(storageService, times(0)).store(any(), any());
+        verify(storageService, times(0)).store(any(), eq(expectedContent));
+        verify(storageService, times(0)).delete(any());
+        verify(fileGateway, times(0)).findByFolder(any());
+        verify(fileGateway, times(0)).create(any());
+
+    }
+
+    @Test
     void givenAValidParamsWithAlreadyExistingFileNameOnSameFolder_whenCallsExecute_thenShouldThrowValidationException() {
 
         final var owner = Member.create(MemberID.of("owner"))
@@ -212,9 +256,6 @@ public class DefaultCreateFileUseCaseTest {
         when(folderGateway.findById(any()))
                 .thenReturn(Optional.of(folder));
 
-        when(storageService.store(any(), any()))
-                .then(returnsFirstArg());
-
         final var input = CreateFileInput.of(
                 ownerId.getValue(),
                 expectedFolderId.getValue(),
@@ -230,8 +271,7 @@ public class DefaultCreateFileUseCaseTest {
 
         verify(folderGateway, times(1)).findById(any());
         verify(folderGateway, times(1)).findById(eq(expectedFolderId));
-        verify(storageService, times(1)).store(any(), any());
-        verify(storageService, times(1)).store(any(), eq(expectedContent));
+        verify(storageService, times(0)).store(any(), any());
         verify(storageService, times(0)).delete(any());
         verify(fileGateway, times(1)).findByFolder(any());
         verify(fileGateway, times(1)).findByFolder(eq(folder.getId()));
@@ -438,8 +478,169 @@ public class DefaultCreateFileUseCaseTest {
         verify(folderGateway, times(1)).findById(eq(expectedFolderId));
         verify(storageService, times(1)).store(any(), any());
         verify(storageService, times(1)).store(any(), eq(expectedContent));
+        verify(fileGateway, times(1)).findByFolder(any());
+        verify(fileGateway, times(1)).findByFolder(eq(expectedFolderId));
         verify(storageService, times(0)).delete(any());
+        verify(fileGateway, times(0)).create(any());
+
+    }
+
+    @Test
+    void givenAnInvalidFileName_whenCallsExecute_thenShouldThrowValidationException() {
+
+        final var owner = Member.create(MemberID.of("owner"))
+                .requestQuota(Quota.of(1, QuotaUnit.GIGABYTE))
+                .approveQuotaRequest();
+
+        final var ownerId = owner.getId();
+
+        final var folder = Folder.createRoot(ownerId);
+        final var expectedFolderId = folder.getId();
+
+        final var expectedFileName = FileName.of("NUL");
+        final var expectedContentType = "image/jpeg";
+        final var contentBytes = "content".getBytes();
+
+        final var expectedContent = new ByteArrayInputStream(contentBytes);
+        final var expectedContentSize = (long) contentBytes.length;
+
+        final var expectedExceptionMessage = "Could not create Aggregate File";
+        final var expectedErrorCount = 1;
+        final var expectedErrorMessage = "'name' cannot be a reserved name: NUL";
+
+        when(memberGateway.findById(ownerId))
+                .thenReturn(Optional.of(owner));
+
+        when(folderGateway.findById(expectedFolderId))
+                .thenReturn(Optional.of(folder));
+
+        final var input = CreateFileInput.of(
+                ownerId.getValue(),
+                expectedFolderId.getValue(),
+                expectedFileName.value(),
+                expectedContentType,
+                expectedContent,
+                expectedContentSize);
+
+        final var actualException = assertThrows(ValidationException.class, () -> useCase.execute(input));
+
+        assertEquals(expectedExceptionMessage, actualException.getMessage());
+        assertEquals(expectedErrorCount, actualException.getErrors().size());
+        assertEquals(expectedErrorMessage, actualException.getErrors().get(0).message());
+
+        verify(folderGateway, times(1)).findById(any());
+        verify(folderGateway, times(1)).findById(eq(expectedFolderId));
+        verify(storageService, times(0)).store(any(), any());
         verify(fileGateway, times(0)).findByFolder(any());
+        verify(storageService, times(0)).delete(any());
+        verify(fileGateway, times(0)).create(any());
+
+    }
+
+    @Test
+    void givenAValidParams_whenCallsExecuteAndMemberQuotaIsExceeded_thenShouldThrowsQuotaExceededException() {
+
+        final var owner = Member.create(MemberID.of("owner"))
+                .requestQuota(Quota.of(1, QuotaUnit.BYTE))
+                .approveQuotaRequest();
+
+        final var ownerId = owner.getId();
+
+        final var folder = Folder.createRoot(ownerId);
+        final var expectedFolderId = folder.getId();
+
+        final var expectedFileName = FileName.of("NUL");
+        final var expectedContentType = "image/jpeg";
+        final var contentBytes = "content".getBytes();
+
+        final var expectedContent = new ByteArrayInputStream(contentBytes);
+        final var expectedContentSize = (long) contentBytes.length;
+
+        final var expectedExceptionMessage = "Quota exceeded";
+        final var expectedErrorCount = 1;
+        final var expectedErrorMessage = "You have exceeded your actual quota of 1 bytes";
+
+        when(memberGateway.findById(ownerId))
+                .thenReturn(Optional.of(owner));
+
+        final var input = CreateFileInput.of(
+                ownerId.getValue(),
+                expectedFolderId.getValue(),
+                expectedFileName.value(),
+                expectedContentType,
+                expectedContent,
+                expectedContentSize);
+
+        final var actualException = assertThrows(QuotaExceededException.class, () -> useCase.execute(input));
+
+        assertEquals(expectedExceptionMessage, actualException.getMessage());
+        assertEquals(expectedErrorCount, actualException.getErrors().size());
+        assertEquals(expectedErrorMessage, actualException.getErrors().get(0).message());
+
+        verify(folderGateway, times(0)).findById(any());
+        verify(storageService, times(0)).store(any(), any());
+        verify(fileGateway, times(0)).findByFolder(any());
+        verify(storageService, times(0)).delete(any());
+        verify(fileGateway, times(0)).create(any());
+
+    }
+
+    @Test
+    void givenAnInvalidParamsWithContentTypeNull_whenCallsExecute_thenShouldThrowsValidationException() {
+
+        final var owner = Member.create(MemberID.of("owner"))
+                .requestQuota(Quota.of(1, QuotaUnit.GIGABYTE))
+                .approveQuotaRequest();
+
+        final var ownerId = owner.getId();
+
+        final var folder = Folder.createRoot(ownerId);
+        final var expectedFolderId = folder.getId();
+
+        final var expectedFileName = FileName.of("file");
+        final String expectedContentType = null;
+        final var contentBytes = "content".getBytes();
+
+        final var expectedContent = new ByteArrayInputStream(contentBytes);
+        final var expectedContentSize = (long) contentBytes.length;
+
+        final var expectedExceptionMessage = "Could not create Aggregate File";
+        final var expectedErrorCount = 1;
+        final var expectedErrorMessage = "'type' cannot be null.";
+
+        when(memberGateway.findById(any()))
+                .thenReturn(Optional.of(owner));
+
+        when(fileGateway.findByFolder(any()))
+                .thenReturn(List.of());
+
+        when(folderGateway.findById(any()))
+                .thenReturn(Optional.of(folder));
+
+        when(storageService.store(any(), any()))
+                .then(returnsFirstArg());
+
+        final var input = CreateFileInput.of(
+                ownerId.getValue(),
+                expectedFolderId.getValue(),
+                expectedFileName.value(),
+                expectedContentType,
+                expectedContent,
+                expectedContentSize);
+
+        final var actualException = assertThrows(ValidationException.class, () -> useCase.execute(input));
+
+        assertEquals(expectedExceptionMessage, actualException.getMessage());
+        assertEquals(expectedErrorCount, actualException.getErrors().size());
+        assertEquals(expectedErrorMessage, actualException.getErrors().get(0).message());
+
+        verify(folderGateway, times(1)).findById(any());
+        verify(folderGateway, times(1)).findById(eq(expectedFolderId));
+        verify(storageService, times(1)).store(any(), any());
+        verify(storageService, times(1)).store(any(), eq(expectedContent));
+        verify(storageService, times(0)).delete(any());
+        verify(fileGateway, times(1)).findByFolder(any());
+        verify(fileGateway, times(1)).findByFolder(eq(folder.getId()));
         verify(fileGateway, times(0)).create(any());
 
     }


### PR DESCRIPTION
This pull request enhances file creation functionality by improving validation and exception handling in the `DefaultCreateFileUseCase` class and updating its corresponding test suite. Key changes include stricter validation for file names, enhanced quota checks, and additional test cases to cover new scenarios.

### Enhancements to validation and exception handling:

* Introduced validation for file names to ensure they are not reserved or duplicate within the same folder. Added a `Notification` object to collect validation errors, and a `ValidationException` is thrown if errors are present. (`DefaultCreateFileUseCase.java`, [[1]](diffhunk://#diff-a4fafd915d541ac669c652b8f4eba69bbf734f8b65c18ad9d6b42ba1ae40b328L62-R79) [[2]](diffhunk://#diff-a4fafd915d541ac669c652b8f4eba69bbf734f8b65c18ad9d6b42ba1ae40b328L78-L84)
* Updated quota check logic to use the `Error.with` method for consistency when throwing `QuotaExceededException`. (`DefaultCreateFileUseCase.java`, [application/src/main/java/com/callv2/drive/application/file/create/DefaultCreateFileUseCase.javaL62-R79](diffhunk://#diff-a4fafd915d541ac669c652b8f4eba69bbf734f8b65c18ad9d6b42ba1ae40b328L62-R79))

### Test suite improvements:

* Added test cases to validate new scenarios, including:
  - Invalid member ID leading to a `NotFoundException`.
  - Invalid file names (e.g., reserved names like "NUL") causing a `ValidationException`.
  - Quota exceeded scenarios resulting in a `QuotaExceededException`.
  - Null content type causing a `ValidationException`.
* Renamed test methods for clarity, such as changing `givenAnInvalidId_whenCallsExecute_thenShouldThrowNotFoundException` to `givenAnInvalidFolderId_whenCallsExecute_thenShouldThrowNotFoundException`.

### Code cleanup:

* Removed redundant logic for file name validation and notification handling in the `DefaultCreateFileUseCase` class, as these are now handled earlier in the process. (`DefaultCreateFileUseCase.java`, [application/src/main/java/com/callv2/drive/application/file/create/DefaultCreateFileUseCase.javaL78-L84](diffhunk://#diff-a4fafd915d541ac669c652b8f4eba69bbf734f8b65c18ad9d6b42ba1ae40b328L78-L84))
* Adjusted test verifications to align with updated validation logic, ensuring no unnecessary operations (e.g., file storage) are performed when validation fails. [[1]](diffhunk://#diff-1aa78b9ffd6c3fb15604e1fab12a5c066985eaef4bcd3249b06bebc1a687e3caL215-L217) [[2]](diffhunk://#diff-1aa78b9ffd6c3fb15604e1fab12a5c066985eaef4bcd3249b06bebc1a687e3caL233-R274)