### PR TITLE
Feature/list quotas

### DIFF
--- a/application/src/main/java/com/callv2/drive/application/member/quota/retrieve/list/DefaultListQuotasUseCase.java
+++ b/application/src/main/java/com/callv2/drive/application/member/quota/retrieve/list/DefaultListQuotasUseCase.java
@@ -1,15 +1,24 @@
 package com.callv2.drive.application.member.quota.retrieve.list;
 
+import com.callv2.drive.domain.member.MemberGateway;
 import com.callv2.drive.domain.pagination.Page;
 import com.callv2.drive.domain.pagination.SearchQuery;
 
 public class DefaultListQuotasUseCase extends ListQuotasUseCase {
 
-    @Override
-    public Page<QuotaListOutput> execute(SearchQuery query) {
+    private final MemberGateway memberGateway;
 
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'execute'");
+    public DefaultListQuotasUseCase(final MemberGateway memberGateway) {
+        this.memberGateway = memberGateway;
+    }
+
+    @Override
+    public Page<ListQuotaOutput> execute(final SearchQuery query) {
+
+        return memberGateway
+                .findAll(query)
+                .map(ListQuotaOutput::of);
+
     }
 
 }

--- a/application/src/main/java/com/callv2/drive/application/member/quota/retrieve/list/ListQuotaOutput.java
+++ b/application/src/main/java/com/callv2/drive/application/member/quota/retrieve/list/ListQuotaOutput.java
@@ -1,0 +1,14 @@
+package com.callv2.drive.application.member.quota.retrieve.list;
+
+import com.callv2.drive.domain.member.Member;
+
+public record ListQuotaOutput(String memberId, String username, Long total) {
+
+    public static ListQuotaOutput of(final Member member) {
+        return new ListQuotaOutput(
+                member.getId().getValue(),
+                member.getUsername().value(),
+                member.getQuota().sizeInBytes());
+    }
+
+}

--- a/application/src/main/java/com/callv2/drive/application/member/quota/retrieve/list/ListQuotasUseCase.java
+++ b/application/src/main/java/com/callv2/drive/application/member/quota/retrieve/list/ListQuotasUseCase.java
@@ -4,6 +4,6 @@ import com.callv2.drive.application.UseCase;
 import com.callv2.drive.domain.pagination.Page;
 import com.callv2.drive.domain.pagination.SearchQuery;
 
-public abstract class ListQuotasUseCase extends UseCase<SearchQuery, Page<QuotaListOutput>> {
+public abstract class ListQuotasUseCase extends UseCase<SearchQuery, Page<ListQuotaOutput>> {
 
 }

--- a/application/src/main/java/com/callv2/drive/application/member/quota/retrieve/list/QuotaListOutput.java
+++ b/application/src/main/java/com/callv2/drive/application/member/quota/retrieve/list/QuotaListOutput.java
@@ -1,9 +1,0 @@
-package com.callv2.drive.application.member.quota.retrieve.list;
-
-public record QuotaListOutput(String memberId, Long amount) {
-
-    public static QuotaListOutput of(String memberId, Long amount) {
-        return new QuotaListOutput(memberId, amount);
-    }
-
-}

--- a/domain/src/main/java/com/callv2/drive/domain/member/MemberGateway.java
+++ b/domain/src/main/java/com/callv2/drive/domain/member/MemberGateway.java
@@ -9,6 +9,8 @@ public interface MemberGateway {
 
     Member create(Member member);
 
+    Page<Member> findAll(SearchQuery searchQuery);
+
     Optional<Member> findById(MemberID id);
 
     Member update(Member member);

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/api/MemberAdminAPI.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/api/MemberAdminAPI.java
@@ -1,5 +1,7 @@
 package com.callv2.drive.infrastructure.api;
 
+import java.util.List;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -7,9 +9,11 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import com.callv2.drive.domain.pagination.Filter;
 import com.callv2.drive.domain.pagination.Page;
 import com.callv2.drive.domain.pagination.Pagination;
 import com.callv2.drive.infrastructure.api.controller.ApiError;
+import com.callv2.drive.infrastructure.member.model.MemberQuotaListResponse;
 import com.callv2.drive.infrastructure.member.model.MemberQuotaResponse;
 import com.callv2.drive.infrastructure.member.model.QuotaRequestListResponse;
 
@@ -48,5 +52,18 @@ public interface MemberAdminAPI {
             @RequestParam(name = "perPage", required = false, defaultValue = "10") final int perPage,
             @RequestParam(name = "orderField", required = false, defaultValue = "quotaRequestedAt") String orderField,
             @RequestParam(name = "orderDirection", required = false, defaultValue = "DESC") Pagination.Order.Direction orderDirection);
+
+    @Operation(summary = "List members quotas", description = "This method list members quotas", security = @SecurityRequirement(name = "bearerAuth"))
+    @ApiResponse(responseCode = "200", description = "Quota members listed successfully", content = @Content(schema = @Schema(implementation = Page.class, subTypes = {
+            MemberQuotaListResponse.class })))
+    @ApiResponse(responseCode = "500", description = "Internal Server Error", content = @Content(schema = @Schema(implementation = ApiError.class)))
+    @GetMapping("quotas")
+    ResponseEntity<Page<MemberQuotaListResponse>> listQuotas(
+            @RequestParam(name = "page", required = false, defaultValue = "0") final int page,
+            @RequestParam(name = "perPage", required = false, defaultValue = "10") final int perPage,
+            @RequestParam(name = "orderField", required = false, defaultValue = "createdAt") String orderField,
+            @RequestParam(name = "orderDirection", required = false, defaultValue = "DESC") Pagination.Order.Direction orderDirection,
+            @RequestParam(name = "filterOperator", required = false, defaultValue = "AND") Filter.Operator filterOperator,
+            @RequestParam(name = "filters", required = false) List<String> filters);
 
 }

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/api/controller/MemberAdminController.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/api/controller/MemberAdminController.java
@@ -10,10 +10,16 @@ import com.callv2.drive.application.member.quota.request.approve.ApproveRequestQ
 import com.callv2.drive.application.member.quota.request.list.ListRequestQuotaUseCase;
 import com.callv2.drive.application.member.quota.retrieve.get.GetQuotaInput;
 import com.callv2.drive.application.member.quota.retrieve.get.GetQuotaUseCase;
+import com.callv2.drive.application.member.quota.retrieve.list.ListQuotasUseCase;
+import com.callv2.drive.domain.pagination.Filter;
+import com.callv2.drive.domain.pagination.Filter.Operator;
 import com.callv2.drive.domain.pagination.Page;
 import com.callv2.drive.domain.pagination.Pagination;
+import com.callv2.drive.domain.pagination.Pagination.Order.Direction;
 import com.callv2.drive.domain.pagination.SearchQuery;
 import com.callv2.drive.infrastructure.api.MemberAdminAPI;
+import com.callv2.drive.infrastructure.filter.adapter.QueryAdapter;
+import com.callv2.drive.infrastructure.member.model.MemberQuotaListResponse;
 import com.callv2.drive.infrastructure.member.model.MemberQuotaResponse;
 import com.callv2.drive.infrastructure.member.model.QuotaRequestListResponse;
 import com.callv2.drive.infrastructure.member.presenter.MemberPresenter;
@@ -24,14 +30,17 @@ public class MemberAdminController implements MemberAdminAPI {
     private final ApproveRequestQuotaUseCase approveRequestQuotaUseCase;
     private final ListRequestQuotaUseCase listRequestQuotaUseCase;
     private final GetQuotaUseCase getQuotaUseCase;
+    private final ListQuotasUseCase listQuotasUseCase;
 
     public MemberAdminController(
             final ApproveRequestQuotaUseCase approveRequestQuotaUseCase,
             final ListRequestQuotaUseCase listRequestQuotaUseCase,
-            final GetQuotaUseCase getQuotaUseCase) {
+            final GetQuotaUseCase getQuotaUseCase,
+            final ListQuotasUseCase listQuotasUseCase) {
         this.approveRequestQuotaUseCase = approveRequestQuotaUseCase;
         this.listRequestQuotaUseCase = listRequestQuotaUseCase;
         this.getQuotaUseCase = getQuotaUseCase;
+        this.listQuotasUseCase = listQuotasUseCase;
     }
 
     @Override
@@ -58,6 +67,30 @@ public class MemberAdminController implements MemberAdminAPI {
                 List.of());
 
         return ResponseEntity.ok(listRequestQuotaUseCase.execute(query).map(MemberPresenter::present));
+
+    }
+
+    @Override
+    public ResponseEntity<Page<MemberQuotaListResponse>> listQuotas(
+            int page,
+            int perPage,
+            String orderField,
+            Direction orderDirection,
+            Operator filterOperator,
+            List<String> filters) {
+
+        final List<Filter> searchFilters = filters == null ? List.of()
+                : filters
+                        .stream()
+                        .map(QueryAdapter::of)
+                        .toList();
+
+        final SearchQuery query = SearchQuery.of(
+                Pagination.of(page, perPage, Pagination.Order.of(orderField, orderDirection)),
+                filterOperator,
+                searchFilters);
+
+        return ResponseEntity.ok(listQuotasUseCase.execute(query).map(MemberPresenter::present));
 
     }
 

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/configuration/usecase/MemberUseCaseConfig.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/configuration/usecase/MemberUseCaseConfig.java
@@ -11,6 +11,8 @@ import com.callv2.drive.application.member.quota.request.list.DefaultListRequest
 import com.callv2.drive.application.member.quota.request.list.ListRequestQuotaUseCase;
 import com.callv2.drive.application.member.quota.retrieve.get.DefaultGetQuotaUseCase;
 import com.callv2.drive.application.member.quota.retrieve.get.GetQuotaUseCase;
+import com.callv2.drive.application.member.quota.retrieve.list.DefaultListQuotasUseCase;
+import com.callv2.drive.application.member.quota.retrieve.list.ListQuotasUseCase;
 import com.callv2.drive.application.member.synchronize.DefaultSynchronizeMemberUseCase;
 import com.callv2.drive.application.member.synchronize.SynchronizeMemberUseCase;
 import com.callv2.drive.domain.file.FileGateway;
@@ -50,6 +52,11 @@ public class MemberUseCaseConfig {
     @Bean
     SynchronizeMemberUseCase synchronizeMemberUseCase() {
         return new DefaultSynchronizeMemberUseCase(memberGateway);
+    }
+
+    @Bean
+    ListQuotasUseCase listQuotasUseCase() {
+        return new DefaultListQuotasUseCase(memberGateway);
     }
 
 }

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/member/model/MemberQuotaListResponse.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/member/model/MemberQuotaListResponse.java
@@ -1,0 +1,5 @@
+package com.callv2.drive.infrastructure.member.model;
+
+public record MemberQuotaListResponse(String memberId, String username, Long total) {
+
+}

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/member/persistence/MemberJpaRepository.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/member/persistence/MemberJpaRepository.java
@@ -4,6 +4,7 @@ import java.time.Instant;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -13,6 +14,8 @@ import com.callv2.drive.domain.member.QuotaRequestPreview;
 import com.callv2.drive.domain.member.QuotaUnit;
 
 public interface MemberJpaRepository extends JpaRepository<MemberJpaEntity, String> {
+
+    Page<MemberJpaEntity> findAll(Specification<MemberJpaEntity> whereClause, Pageable page);
 
     @Query("""
             select distinct new com.callv2.drive.domain.member.QuotaRequestPreview(

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/member/presenter/MemberPresenter.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/member/presenter/MemberPresenter.java
@@ -2,6 +2,8 @@ package com.callv2.drive.infrastructure.member.presenter;
 
 import com.callv2.drive.application.member.quota.request.list.ListRequestQuotaOutput;
 import com.callv2.drive.application.member.quota.retrieve.get.GetQuotaOutput;
+import com.callv2.drive.application.member.quota.retrieve.list.ListQuotaOutput;
+import com.callv2.drive.infrastructure.member.model.MemberQuotaListResponse;
 import com.callv2.drive.infrastructure.member.model.MemberQuotaResponse;
 import com.callv2.drive.infrastructure.member.model.QuotaRequestListResponse;
 
@@ -18,7 +20,19 @@ public interface MemberPresenter {
     }
 
     static MemberQuotaResponse present(final GetQuotaOutput output) {
-        return new MemberQuotaResponse(output.memberId(), output.used(), output.total(), output.available());
+        return new MemberQuotaResponse(
+                output.memberId(),
+                output.username(),
+                output.used(),
+                output.total(),
+                output.available());
+    }
+
+    static MemberQuotaListResponse present(final ListQuotaOutput output) {
+        return new MemberQuotaListResponse(
+                output.memberId(),
+                output.username(),
+                output.total());
     }
 
 }

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/member/presenter/MemberPresenter.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/member/presenter/MemberPresenter.java
@@ -22,7 +22,6 @@ public interface MemberPresenter {
     static MemberQuotaResponse present(final GetQuotaOutput output) {
         return new MemberQuotaResponse(
                 output.memberId(),
-                output.username(),
                 output.used(),
                 output.total(),
                 output.available());


### PR DESCRIPTION
This pull request introduces a new feature for listing member quotas, refactors related application and infrastructure layers, and updates the API to expose this functionality. The main changes include the addition of the `ListQuotasUseCase` and its implementation, integration with the API and controller, and supporting updates to the gateway and data mapping. Below are the most important changes grouped by theme:

**Application Layer: Member Quota Listing**

* Added the `ListQuotasUseCase` abstract class and its concrete implementation `DefaultListQuotasUseCase`, which retrieves paginated member quota data using the new `ListQuotaOutput` record. (`application/src/main/java/com/callv2/drive/application/member/quota/retrieve/list/ListQuotasUseCase.java`, `DefaultListQuotasUseCase.java`, `ListQuotaOutput.java`) [[1]](diffhunk://#diff-457b0dd13635f3e852790b087aa9743dae1d7d6965954c1e3fb9448033eba6cdL7-R7) [[2]](diffhunk://#diff-1cd81131b6060eefc2f7c4d350ffb071549e669781d1f6453a09845f73a6ff11R3-L12) [[3]](diffhunk://#diff-3bb9f124c4e78cc24116c2f1ac870b08db11f59611da0ac6b73c104a83bfdbd7R1-R14)
* Removed the obsolete `QuotaListOutput` record, replacing it with the more detailed `ListQuotaOutput`. (`application/src/main/java/com/callv2/drive/application/member/quota/retrieve/list/QuotaListOutput.java`)

**Infrastructure Layer: Gateway and Repository Updates**

* Implemented the `findAll(SearchQuery)` method in `DefaultMemberGateway` to support paginated and filtered member queries, leveraging Spring Data JPA specifications and pagination. Updated constructor to inject `FilterService`. (`infrastructure/src/main/java/com/callv2/drive/infrastructure/member/DefaultMemberGateway.java`) [[1]](diffhunk://#diff-ad5dcf49c85084ae9c661202d03ecadd6da5a605972f5a436026a3c746c16078R19-R33) [[2]](diffhunk://#diff-ad5dcf49c85084ae9c661202d03ecadd6da5a605972f5a436026a3c746c16078R45-R66)
* Extended `MemberJpaRepository` to support specification-based queries for member entities. (`infrastructure/src/main/java/com/callv2/drive/infrastructure/member/persistence/MemberJpaRepository.java`)

**API Layer: Endpoint and Controller Integration**

* Added the `listQuotas` endpoint to `MemberAdminAPI` for listing member quotas with pagination, ordering, and filtering options. (`infrastructure/src/main/java/com/callv2/drive/infrastructure/api/MemberAdminAPI.java`)
* Implemented the corresponding controller method in `MemberAdminController`, wiring through the use case and mapping results to the response model. (`infrastructure/src/main/java/com/callv2/drive/infrastructure/api/controller/MemberAdminController.java`) [[1]](diffhunk://#diff-a83074e73dacb0218c2418ac388ce678bceb4540a2d33ec6c79203ead96aeea1R33-R43) [[2]](diffhunk://#diff-a83074e73dacb0218c2418ac388ce678bceb4540a2d33ec6c79203ead96aeea1R73-R96)

**Configuration and Data Mapping**

* Registered the new use case bean in `MemberUseCaseConfig` for dependency injection. (`infrastructure/src/main/java/com/callv2/drive/infrastructure/configuration/usecase/MemberUseCaseConfig.java`)
* Added `MemberQuotaListResponse` record and updated `MemberPresenter` to map domain output to API response. (`infrastructure/src/main/java/com/callv2/drive/infrastructure/member/model/MemberQuotaListResponse.java`, `MemberPresenter.java`) [[1]](diffhunk://#diff-f6fb1948e6978cf81e20ae8a76ef36d2635ff8ac3fa78f77cefb5bc9aae3ee0eR1-R5) [[2]](diffhunk://#diff-12b43fd72d05ff610a664da481dc94e0f28a2006babdfcb164559bd57c453806L21-R35)

These changes collectively enable efficient, paginated, and filterable listing of member quotas via the API, with proper separation of concerns and mapping between layers.