### PR TITLE
fix: ensure case-insensitive filtering in Like specification

### DIFF
--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/filter/Like.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/filter/Like.java
@@ -24,7 +24,7 @@ public class Like extends SpecificationFilter {
         validateFilter(filter);
 
         return (root, query, criteriaBuilder) -> criteriaBuilder
-                .like(root.get(filter.field()), "%" + filter.value() + "%");
+                .like(criteriaBuilder.upper(root.get(filter.field())), "%" + filter.value().toUpperCase() + "%");
     }
 
     private void validateFilter(final Filter filter) {


### PR DESCRIPTION
This pull request updates the filtering logic in the `Like` specification to make string comparisons case-insensitive. This change improves search functionality so that queries match regardless of text case.

Filtering improvements:

* Modified the `buildSpecification` method in `Like.java` to use `criteriaBuilder.upper` and `filter.value().toUpperCase()`, ensuring case-insensitive matching for LIKE queries.