### PR TITLE
feat: include username in quota output and response models

### DIFF
--- a/application/src/main/java/com/callv2/drive/application/member/quota/retrieve/get/DefaultGetQuotaUseCase.java
+++ b/application/src/main/java/com/callv2/drive/application/member/quota/retrieve/get/DefaultGetQuotaUseCase.java
@@ -34,9 +34,8 @@ public class DefaultGetQuotaUseCase extends GetQuotaUseCase {
                 .mapToLong(Content::size)
                 .sum();
 
-        final Long available = owner.getQuota().sizeInBytes() - actualUsedQuota;
+        return GetQuotaOutput.from(owner, actualUsedQuota);
 
-        return GetQuotaOutput.from(ownerId.getValue(), actualUsedQuota, owner.getQuota().sizeInBytes(), available);
     }
 
 }

--- a/application/src/main/java/com/callv2/drive/application/member/quota/retrieve/get/GetQuotaOutput.java
+++ b/application/src/main/java/com/callv2/drive/application/member/quota/retrieve/get/GetQuotaOutput.java
@@ -1,9 +1,16 @@
 package com.callv2.drive.application.member.quota.retrieve.get;
 
-public record GetQuotaOutput(String memberId, Long used, Long total, Long available) {
+import com.callv2.drive.domain.member.Member;
 
-    public static GetQuotaOutput from(final String memberId, final Long used, final Long total, final Long available) {
-        return new GetQuotaOutput(memberId, used, total, available);
+public record GetQuotaOutput(String memberId, String username, Long used, Long total, Long available) {
+
+    public static GetQuotaOutput from(final Member member, final Long usedQuotaInBytes) {
+        return new GetQuotaOutput(
+                member.getId().getValue(),
+                member.getUsername().value(),
+                usedQuotaInBytes,
+                member.getQuota().sizeInBytes(),
+                member.getQuota().sizeInBytes() - usedQuotaInBytes);
     }
 
 }

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/member/model/MemberQuotaResponse.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/member/model/MemberQuotaResponse.java
@@ -1,5 +1,5 @@
 package com.callv2.drive.infrastructure.member.model;
 
-public record MemberQuotaResponse(String memberId, Long used, Long total, Long available) {
+public record MemberQuotaResponse(String memberId, String username, Long used, Long total, Long available) {
 
 }

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/member/presenter/MemberPresenter.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/member/presenter/MemberPresenter.java
@@ -22,6 +22,7 @@ public interface MemberPresenter {
     static MemberQuotaResponse present(final GetQuotaOutput output) {
         return new MemberQuotaResponse(
                 output.memberId(),
+                output.username(),
                 output.used(),
                 output.total(),
                 output.available());


### PR DESCRIPTION
This pull request updates the member quota retrieval feature to include the member's username in both the output and response objects, and refactors how quota information is constructed and returned. The changes improve the clarity and completeness of the data provided by the quota endpoints.

**Enhancements to quota data structures:**

* Added the `username` field to both `GetQuotaOutput` and `MemberQuotaResponse` records, ensuring that the member's username is included in quota responses. [[1]](diffhunk://#diff-fcf56b06f21d638002da83fc363a1db494003888c08e15782539277e3a34a2f3L3-R13) [[2]](diffhunk://#diff-3c42750b1dc9a2ddbcfab848e972160ab916455be046446f8653c269fa5c4cbfL3-R3)
* Updated the `present` method in `MemberPresenter` to include the `username` field when constructing a `MemberQuotaResponse`.

**Refactoring of quota calculation logic:**

* Refactored `DefaultGetQuotaUseCase` to use the new `GetQuotaOutput.from(Member, Long)` factory method, simplifying quota calculation and output construction.
* Updated the `GetQuotaOutput` factory method to accept a `Member` object and derive all necessary fields, including the new `username` field.