### PR TITLE
Feature/quota summary

### DIFF
--- a/application/src/main/java/com/callv2/drive/application/member/quota/request/create/CreateRequestQuotaInput.java
+++ b/application/src/main/java/com/callv2/drive/application/member/quota/request/create/CreateRequestQuotaInput.java
@@ -2,7 +2,7 @@ package com.callv2.drive.application.member.quota.request.create;
 
 import com.callv2.drive.domain.member.QuotaUnit;
 
-public record CreateRequestQuotaInput(String memberId, Long ammount, QuotaUnit unit) {
+public record CreateRequestQuotaInput(String memberId, Long amount, QuotaUnit unit) {
 
     public static CreateRequestQuotaInput of(String memberId, Long amount, QuotaUnit unit) {
         return new CreateRequestQuotaInput(memberId, amount, unit);

--- a/application/src/main/java/com/callv2/drive/application/member/quota/request/create/DefaultCreateRequestQuotaUseCase.java
+++ b/application/src/main/java/com/callv2/drive/application/member/quota/request/create/DefaultCreateRequestQuotaUseCase.java
@@ -28,7 +28,7 @@ public class DefaultCreateRequestQuotaUseCase extends CreateRequestQuotaUseCase 
                 .orElseThrow(() -> NotFoundException.with(Member.class, input.memberId()));
 
         final Notification notification = Notification.create();
-        notification.validate(() -> member.requestQuota(Quota.of(input.ammount(), input.unit())));
+        notification.validate(() -> member.requestQuota(Quota.of(input.amount(), input.unit())));
 
         if (notification.hasError())
             throw ValidationException.with("Request Quota Error", notification);

--- a/application/src/main/java/com/callv2/drive/application/member/quota/retrieve/summary/DefaultGetQuotasSummaryUseCase.java
+++ b/application/src/main/java/com/callv2/drive/application/member/quota/retrieve/summary/DefaultGetQuotasSummaryUseCase.java
@@ -1,0 +1,33 @@
+package com.callv2.drive.application.member.quota.retrieve.summary;
+
+import com.callv2.drive.domain.file.FileGateway;
+import com.callv2.drive.domain.member.MemberGateway;
+
+public class DefaultGetQuotasSummaryUseCase extends GetQuotasSummaryUseCase {
+
+    private final MemberGateway memberGateway;
+    private final FileGateway fileGateway;
+
+    public DefaultGetQuotasSummaryUseCase(
+            final MemberGateway memberGateway,
+            final FileGateway fileGateway) {
+        this.memberGateway = memberGateway;
+        this.fileGateway = fileGateway;
+    }
+
+    @Override
+    public GetQuotasSummaryOutput execute() {
+
+        final Long totalMembers = this.memberGateway.count();
+        final Long totalAllocatedQuota = this.memberGateway.sumAllQuota();
+        final Long totalUsedStorage = this.fileGateway.sumAllContentSize();
+
+        return new GetQuotasSummaryOutput(
+                totalMembers,
+                totalAllocatedQuota,
+                totalUsedStorage,
+                totalAllocatedQuota - totalUsedStorage);
+
+    }
+
+}

--- a/application/src/main/java/com/callv2/drive/application/member/quota/retrieve/summary/GetQuotasSummaryOutput.java
+++ b/application/src/main/java/com/callv2/drive/application/member/quota/retrieve/summary/GetQuotasSummaryOutput.java
@@ -1,0 +1,9 @@
+package com.callv2.drive.application.member.quota.retrieve.summary;
+
+public record GetQuotasSummaryOutput(
+        Long membersCount,
+        Long totalAllocatedQuota,
+        Long totalUsedQuota,
+        Long totalAvailableQuota) {
+
+}

--- a/application/src/main/java/com/callv2/drive/application/member/quota/retrieve/summary/GetQuotasSummaryUseCase.java
+++ b/application/src/main/java/com/callv2/drive/application/member/quota/retrieve/summary/GetQuotasSummaryUseCase.java
@@ -1,0 +1,7 @@
+package com.callv2.drive.application.member.quota.retrieve.summary;
+
+import com.callv2.drive.application.NullaryUseCase;
+
+public abstract class GetQuotasSummaryUseCase extends NullaryUseCase<GetQuotasSummaryOutput> {
+
+}

--- a/domain/src/main/java/com/callv2/drive/domain/file/FileGateway.java
+++ b/domain/src/main/java/com/callv2/drive/domain/file/FileGateway.java
@@ -22,4 +22,6 @@ public interface FileGateway {
 
     void deleteById(FileID id);
 
+    Long sumAllContentSize();
+
 }

--- a/domain/src/main/java/com/callv2/drive/domain/member/MemberGateway.java
+++ b/domain/src/main/java/com/callv2/drive/domain/member/MemberGateway.java
@@ -9,6 +9,8 @@ public interface MemberGateway {
 
     Member create(Member member);
 
+    Long count();
+
     Page<Member> findAll(SearchQuery searchQuery);
 
     Optional<Member> findById(MemberID id);
@@ -18,5 +20,7 @@ public interface MemberGateway {
     Page<QuotaRequestPreview> findAllQuotaRequests(final SearchQuery searchQuery);
 
     Boolean existsById(MemberID id);
+
+    Long sumAllQuota();
 
 }

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/api/MemberAPI.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/api/MemberAPI.java
@@ -21,7 +21,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 @RequestMapping("members")
 public interface MemberAPI {
 
-    @Operation(summary = "Request drive quota", description = "This method request a drive ammount quota", security = @SecurityRequirement(name = "bearerAuth"))
+    @Operation(summary = "Request drive quota", description = "This method request a drive amount quota", security = @SecurityRequirement(name = "bearerAuth"))
     @ApiResponse(responseCode = "204", description = "Requested successfuly")
     @ApiResponse(responseCode = "404", description = "Member not found", content = @Content(schema = @Schema(implementation = Void.class)))
     @PostMapping("quotas/requests/{amount}")
@@ -29,7 +29,7 @@ public interface MemberAPI {
             @PathVariable(value = "amount", required = true) long amount,
             @RequestParam(value = "unit", defaultValue = "GIGABYTE") QuotaUnit unit);
 
-    @Operation(summary = "Retrieve actual drive quota", description = "This method retrieve a drive ammount quota", security = @SecurityRequirement(name = "bearerAuth"))
+    @Operation(summary = "Retrieve actual drive quota", description = "This method retrieve a drive amount quota", security = @SecurityRequirement(name = "bearerAuth"))
     @ApiResponse(responseCode = "200", description = "Retrieve successfuly")
     @ApiResponse(responseCode = "404", description = "Member not found", content = @Content(schema = @Schema(implementation = Void.class)))
     @GetMapping("quotas")

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/api/MemberAdminAPI.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/api/MemberAdminAPI.java
@@ -16,6 +16,7 @@ import com.callv2.drive.infrastructure.api.controller.ApiError;
 import com.callv2.drive.infrastructure.member.model.MemberQuotaListResponse;
 import com.callv2.drive.infrastructure.member.model.MemberQuotaResponse;
 import com.callv2.drive.infrastructure.member.model.QuotaRequestListResponse;
+import com.callv2.drive.infrastructure.member.model.QuotaSummaryResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -65,5 +66,11 @@ public interface MemberAdminAPI {
             @RequestParam(name = "orderDirection", required = false, defaultValue = "DESC") Pagination.Order.Direction orderDirection,
             @RequestParam(name = "filterOperator", required = false, defaultValue = "AND") Filter.Operator filterOperator,
             @RequestParam(name = "filters", required = false) List<String> filters);
+
+    @Operation(summary = "Get quota summary", description = "Returns an aggregated summary of quotas, including total allocated quota, used quota, available quota, and total members.", security = @SecurityRequirement(name = "bearerAuth"))
+    @ApiResponse(responseCode = "200", description = "Quota summary retrieved successfully", content = @Content(schema = @Schema(implementation = QuotaSummaryResponse.class)))
+    @ApiResponse(responseCode = "500", description = "Internal Server Error", content = @Content(schema = @Schema(implementation = ApiError.class)))
+    @GetMapping("quotas/summary")
+    ResponseEntity<QuotaSummaryResponse> quotaSummary();
 
 }

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/api/MemberAdminAPI.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/api/MemberAdminAPI.java
@@ -28,13 +28,13 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 @RequestMapping("admin/members")
 public interface MemberAdminAPI {
 
-    @Operation(summary = "Request drive quota", description = "This method request a drive ammount quota", security = @SecurityRequirement(name = "bearerAuth"))
+    @Operation(summary = "Request drive quota", description = "This method request a drive amount quota", security = @SecurityRequirement(name = "bearerAuth"))
     @ApiResponse(responseCode = "200", description = "Retrieve successfuly")
     @ApiResponse(responseCode = "404", description = "Member not found", content = @Content(schema = @Schema(implementation = Void.class)))
     @GetMapping("{id}/quotas")
     ResponseEntity<MemberQuotaResponse> getQuota(@PathVariable(value = "id", required = true) String id);
 
-    @Operation(summary = "Approve drive quota request", description = "This method approve a drive ammount quota request", security = @SecurityRequirement(name = "bearerAuth"))
+    @Operation(summary = "Approve drive quota request", description = "This method approve a drive amount quota request", security = @SecurityRequirement(name = "bearerAuth"))
     @ApiResponse(responseCode = "204", description = "Approved successfuly")
     @ApiResponse(responseCode = "404", description = "Member not found", content = @Content(schema = @Schema(implementation = Void.class)))
     @PatchMapping("{id}/quotas/requests")

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/api/controller/MemberAdminController.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/api/controller/MemberAdminController.java
@@ -11,6 +11,7 @@ import com.callv2.drive.application.member.quota.request.list.ListRequestQuotaUs
 import com.callv2.drive.application.member.quota.retrieve.get.GetQuotaInput;
 import com.callv2.drive.application.member.quota.retrieve.get.GetQuotaUseCase;
 import com.callv2.drive.application.member.quota.retrieve.list.ListQuotasUseCase;
+import com.callv2.drive.application.member.quota.retrieve.summary.GetQuotasSummaryUseCase;
 import com.callv2.drive.domain.pagination.Filter;
 import com.callv2.drive.domain.pagination.Filter.Operator;
 import com.callv2.drive.domain.pagination.Page;
@@ -22,6 +23,7 @@ import com.callv2.drive.infrastructure.filter.adapter.QueryAdapter;
 import com.callv2.drive.infrastructure.member.model.MemberQuotaListResponse;
 import com.callv2.drive.infrastructure.member.model.MemberQuotaResponse;
 import com.callv2.drive.infrastructure.member.model.QuotaRequestListResponse;
+import com.callv2.drive.infrastructure.member.model.QuotaSummaryResponse;
 import com.callv2.drive.infrastructure.member.presenter.MemberPresenter;
 
 @Controller
@@ -31,16 +33,19 @@ public class MemberAdminController implements MemberAdminAPI {
     private final ListRequestQuotaUseCase listRequestQuotaUseCase;
     private final GetQuotaUseCase getQuotaUseCase;
     private final ListQuotasUseCase listQuotasUseCase;
+    private final GetQuotasSummaryUseCase getQuotasSummaryUseCase;
 
     public MemberAdminController(
             final ApproveRequestQuotaUseCase approveRequestQuotaUseCase,
             final ListRequestQuotaUseCase listRequestQuotaUseCase,
             final GetQuotaUseCase getQuotaUseCase,
-            final ListQuotasUseCase listQuotasUseCase) {
+            final ListQuotasUseCase listQuotasUseCase,
+            final GetQuotasSummaryUseCase getQuotasSummaryUseCase) {
         this.approveRequestQuotaUseCase = approveRequestQuotaUseCase;
         this.listRequestQuotaUseCase = listRequestQuotaUseCase;
         this.getQuotaUseCase = getQuotaUseCase;
         this.listQuotasUseCase = listQuotasUseCase;
+        this.getQuotasSummaryUseCase = getQuotasSummaryUseCase;
     }
 
     @Override
@@ -92,6 +97,11 @@ public class MemberAdminController implements MemberAdminAPI {
 
         return ResponseEntity.ok(listQuotasUseCase.execute(query).map(MemberPresenter::present));
 
+    }
+
+    @Override
+    public ResponseEntity<QuotaSummaryResponse> quotaSummary() {
+        return ResponseEntity.ok(MemberPresenter.present(getQuotasSummaryUseCase.execute()));
     }
 
 }

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/configuration/usecase/MemberUseCaseConfig.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/configuration/usecase/MemberUseCaseConfig.java
@@ -13,6 +13,8 @@ import com.callv2.drive.application.member.quota.retrieve.get.DefaultGetQuotaUse
 import com.callv2.drive.application.member.quota.retrieve.get.GetQuotaUseCase;
 import com.callv2.drive.application.member.quota.retrieve.list.DefaultListQuotasUseCase;
 import com.callv2.drive.application.member.quota.retrieve.list.ListQuotasUseCase;
+import com.callv2.drive.application.member.quota.retrieve.summary.DefaultGetQuotasSummaryUseCase;
+import com.callv2.drive.application.member.quota.retrieve.summary.GetQuotasSummaryUseCase;
 import com.callv2.drive.application.member.synchronize.DefaultSynchronizeMemberUseCase;
 import com.callv2.drive.application.member.synchronize.SynchronizeMemberUseCase;
 import com.callv2.drive.domain.file.FileGateway;
@@ -57,6 +59,11 @@ public class MemberUseCaseConfig {
     @Bean
     ListQuotasUseCase listQuotasUseCase() {
         return new DefaultListQuotasUseCase(memberGateway);
+    }
+
+    @Bean
+    GetQuotasSummaryUseCase getQuotasSummaryUseCase() {
+        return new DefaultGetQuotasSummaryUseCase(memberGateway, fileGateway);
     }
 
 }

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/file/FileJPAGateway.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/file/FileJPAGateway.java
@@ -86,4 +86,9 @@ public class FileJPAGateway implements FileGateway {
         this.fileRepository.deleteById(id.getValue());
     }
 
+    @Override
+    public Long sumAllContentSize() {
+        return this.fileRepository.sumAllContentSize();
+    }
+
 }

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/file/persistence/FileJpaRepository.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/file/persistence/FileJpaRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface FileJpaRepository extends JpaRepository<FileJpaEntity, UUID> {
 
@@ -15,5 +16,8 @@ public interface FileJpaRepository extends JpaRepository<FileJpaEntity, UUID> {
     List<FileJpaEntity> findByFolderId(UUID folderId);
 
     List<FileJpaEntity> findByOwnerId(String ownerId);
+
+    @Query("select coalesce(sum(f.contentSize), 0) from File f")
+    Long sumAllContentSize();
 
 }

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/member/DefaultMemberGateway.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/member/DefaultMemberGateway.java
@@ -43,6 +43,11 @@ public class DefaultMemberGateway implements MemberGateway {
     }
 
     @Override
+    public Long count() {
+        return memberJpaRepository.count();
+    }
+
+    @Override
     public Page<Member> findAll(SearchQuery searchQuery) {
 
         final PageRequest pageRequest = QueryAdapter.of(searchQuery.pagination());
@@ -83,9 +88,9 @@ public class DefaultMemberGateway implements MemberGateway {
                 memberJpa.getId(),
                 memberJpa.getUsername(),
                 memberJpa.getNickname(),
-                memberJpa.getQuotaAmmount(),
+                memberJpa.getQuotaAmount(),
                 memberJpa.getQuotaUnit(),
-                memberJpa.getQuotaRequestAmmount(),
+                memberJpa.getQuotaRequestAmount(),
                 memberJpa.getQuotaRequestUnit(),
                 memberJpa.getQuotaRequestedAt(),
                 memberJpa.getCreatedAt(),
@@ -116,6 +121,11 @@ public class DefaultMemberGateway implements MemberGateway {
     @Override
     public Boolean existsById(MemberID id) {
         return this.memberJpaRepository.existsById(id.getValue());
+    }
+
+    @Override
+    public Long sumAllQuota() {
+        return this.memberJpaRepository.sumAllQuota();
     }
 
 }

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/member/model/QuotaSummaryResponse.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/member/model/QuotaSummaryResponse.java
@@ -1,0 +1,9 @@
+package com.callv2.drive.infrastructure.member.model;
+
+public record QuotaSummaryResponse(
+        Long membersCount,
+        Long totalAllocatedQuota,
+        Long totalUsedQuota,
+        Long totalAvailableQuota) {
+
+}

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/member/persistence/MemberJpaEntity.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/member/persistence/MemberJpaEntity.java
@@ -61,10 +61,10 @@ public class MemberJpaEntity {
             final String username,
             final String nickname,
             final Long quotaInBytes,
-            final Long quotaAmmount,
+            final Long quotaAmount,
             final QuotaUnit quotaUnit,
             final Long quotaRequestInBytes,
-            final Long quotaRequestAmmount,
+            final Long quotaRequestAmount,
             final QuotaUnit quotaRequestUnit,
             final Instant quotaRequestedAt,
             final Boolean hasSystemAccess,
@@ -75,10 +75,10 @@ public class MemberJpaEntity {
         this.username = username;
         this.nickname = nickname;
         this.quotaInBytes = quotaInBytes;
-        this.quotaAmount = quotaAmmount;
+        this.quotaAmount = quotaAmount;
         this.quotaUnit = quotaUnit;
         this.quotaRequestInBytes = quotaRequestInBytes;
-        this.quotaRequestAmount = quotaRequestAmmount;
+        this.quotaRequestAmount = quotaRequestAmount;
         this.quotaRequestUnit = quotaRequestUnit;
         this.quotaRequestedAt = quotaRequestedAt;
         this.hasSystemAccess = hasSystemAccess == null ? false : hasSystemAccess;
@@ -164,8 +164,8 @@ public class MemberJpaEntity {
         return quotaAmount;
     }
 
-    public void setQuotaAmount(Long quotaAmmount) {
-        this.quotaAmount = quotaAmmount;
+    public void setQuotaAmount(Long quotaAmount) {
+        this.quotaAmount = quotaAmount;
     }
 
     public QuotaUnit getQuotaUnit() {
@@ -188,8 +188,8 @@ public class MemberJpaEntity {
         return quotaRequestAmount;
     }
 
-    public void setQuotaRequestAmount(Long quotaRequestAmmount) {
-        this.quotaRequestAmount = quotaRequestAmmount;
+    public void setQuotaRequestAmount(Long quotaRequestAmount) {
+        this.quotaRequestAmount = quotaRequestAmount;
     }
 
     public QuotaUnit getQuotaRequestUnit() {

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/member/persistence/MemberJpaEntity.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/member/persistence/MemberJpaEntity.java
@@ -29,13 +29,18 @@ public class MemberJpaEntity {
     private String nickname;
 
     @Column(nullable = false)
-    private Long quotaAmmount;
+    private Long quotaInBytes;
+
+    @Column(nullable = false)
+    private Long quotaAmount;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private QuotaUnit quotaUnit;
 
-    private Long quotaRequestAmmount;
+    private Long quotaRequestInBytes;
+
+    private Long quotaRequestAmount;
 
     @Enumerated(EnumType.STRING)
     private QuotaUnit quotaRequestUnit;
@@ -55,8 +60,10 @@ public class MemberJpaEntity {
             final String id,
             final String username,
             final String nickname,
+            final Long quotaInBytes,
             final Long quotaAmmount,
             final QuotaUnit quotaUnit,
+            final Long quotaRequestInBytes,
             final Long quotaRequestAmmount,
             final QuotaUnit quotaRequestUnit,
             final Instant quotaRequestedAt,
@@ -67,9 +74,11 @@ public class MemberJpaEntity {
         this.id = id;
         this.username = username;
         this.nickname = nickname;
-        this.quotaAmmount = quotaAmmount;
+        this.quotaInBytes = quotaInBytes;
+        this.quotaAmount = quotaAmmount;
         this.quotaUnit = quotaUnit;
-        this.quotaRequestAmmount = quotaRequestAmmount;
+        this.quotaRequestInBytes = quotaRequestInBytes;
+        this.quotaRequestAmount = quotaRequestAmmount;
         this.quotaRequestUnit = quotaRequestUnit;
         this.quotaRequestedAt = quotaRequestedAt;
         this.hasSystemAccess = hasSystemAccess == null ? false : hasSystemAccess;
@@ -84,16 +93,16 @@ public class MemberJpaEntity {
     public Member toDomain() {
 
         QuotaRequest quotaRequest = null;
-        if (getQuotaRequestAmmount() != null && getQuotaRequestUnit() != null && getQuotaRequestedAt() != null)
+        if (getQuotaRequestAmount() != null && getQuotaRequestUnit() != null && getQuotaRequestedAt() != null)
             quotaRequest = QuotaRequest.of(
-                    Quota.of(getQuotaRequestAmmount(), getQuotaRequestUnit()),
+                    Quota.of(getQuotaRequestAmount(), getQuotaRequestUnit()),
                     getQuotaRequestedAt());
 
         return Member.with(
                 MemberID.of(getId()),
                 Username.of(getUsername()),
                 Nickname.of(getNickname()),
-                Quota.of(getQuotaAmmount(), getQuotaUnit()),
+                Quota.of(getQuotaAmount(), getQuotaUnit()),
                 quotaRequest,
                 getHasSystemAccess(),
                 getCreatedAt(),
@@ -106,8 +115,10 @@ public class MemberJpaEntity {
                 member.getId().getValue(),
                 member.getUsername().value(),
                 member.getNickname().value(),
+                member.getQuota().sizeInBytes(),
                 member.getQuota().amount(),
                 member.getQuota().unit(),
+                member.getQuotaRequest().map(QuotaRequest::quota).map(Quota::sizeInBytes).orElse(null),
                 member.getQuotaRequest().map(QuotaRequest::quota).map(Quota::amount).orElse(null),
                 member.getQuotaRequest().map(QuotaRequest::quota).map(Quota::unit).orElse(null),
                 member.getQuotaRequest().map(QuotaRequest::requesteddAt).orElse(null),
@@ -141,12 +152,20 @@ public class MemberJpaEntity {
         this.nickname = nickname;
     }
 
-    public Long getQuotaAmmount() {
-        return quotaAmmount;
+    public Long getQuotaInBytes() {
+        return quotaInBytes;
     }
 
-    public void setQuotaAmmount(Long quotaAmmount) {
-        this.quotaAmmount = quotaAmmount;
+    public void setQuotaInBytes(Long quotaInBytes) {
+        this.quotaInBytes = quotaInBytes;
+    }
+
+    public Long getQuotaAmount() {
+        return quotaAmount;
+    }
+
+    public void setQuotaAmount(Long quotaAmmount) {
+        this.quotaAmount = quotaAmmount;
     }
 
     public QuotaUnit getQuotaUnit() {
@@ -157,12 +176,20 @@ public class MemberJpaEntity {
         this.quotaUnit = quotaUnit;
     }
 
-    public Long getQuotaRequestAmmount() {
-        return quotaRequestAmmount;
+    public Long getQuotaRequestInBytes() {
+        return quotaRequestInBytes;
     }
 
-    public void setQuotaRequestAmmount(Long quotaRequestAmmount) {
-        this.quotaRequestAmmount = quotaRequestAmmount;
+    public void setQuotaRequestInBytes(Long quotaRequestInBytes) {
+        this.quotaRequestInBytes = quotaRequestInBytes;
+    }
+
+    public Long getQuotaRequestAmount() {
+        return quotaRequestAmount;
+    }
+
+    public void setQuotaRequestAmount(Long quotaRequestAmmount) {
+        this.quotaRequestAmount = quotaRequestAmmount;
     }
 
     public QuotaUnit getQuotaRequestUnit() {

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/member/persistence/MemberJpaRepository.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/member/persistence/MemberJpaRepository.java
@@ -62,4 +62,7 @@ public interface MemberJpaRepository extends JpaRepository<MemberJpaEntity, Stri
             @Param("updatedAt") Instant updatedAt,
             @Param("synchronizedVersion") Long synchronizedVersion);
 
+    @Query("select coalesce(sum(m.quotaInBytes), 0) from Member m")
+    Long sumAllQuota();
+
 }

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/member/persistence/MemberJpaRepository.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/member/persistence/MemberJpaRepository.java
@@ -22,7 +22,7 @@ public interface MemberJpaRepository extends JpaRepository<MemberJpaEntity, Stri
                 m.id as memberId,
                 m.username as memberUsername,
                 m.nickname as memberNickname,
-                m.quotaRequestAmmount as quotaAmount,
+                m.quotaRequestAmount as quotaAmount,
                 m.quotaRequestUnit as quotaUnit,
                 m.quotaRequestedAt as quotaRequestedAt
             )
@@ -38,9 +38,9 @@ public interface MemberJpaRepository extends JpaRepository<MemberJpaEntity, Stri
             set
                 m.username = :username,
                 m.nickname = :nickname,
-                m.quotaAmmount = :quotaAmmount,
+                m.quotaAmount = :quotaAmount,
                 m.quotaUnit = :quotaUnit,
-                m.quotaRequestAmmount = :quotaRequestAmmount,
+                m.quotaRequestAmount = :quotaRequestAmount,
                 m.quotaRequestUnit = :quotaRequestUnit,
                 m.quotaRequestedAt = :quotaRequestedAt,
                 m.createdAt = :createdAt,
@@ -53,9 +53,9 @@ public interface MemberJpaRepository extends JpaRepository<MemberJpaEntity, Stri
             @Param("id") String id,
             @Param("username") String username,
             @Param("nickname") String nickname,
-            @Param("quotaAmmount") Long quotaAmmount,
+            @Param("quotaAmount") Long quotaAmount,
             @Param("quotaUnit") QuotaUnit quotaUnit,
-            @Param("quotaRequestAmmount") Long quotaRequestAmmount,
+            @Param("quotaRequestAmount") Long quotaRequestAmount,
             @Param("quotaRequestUnit") QuotaUnit quotaRequestUnit,
             @Param("quotaRequestedAt") Instant quotaRequestedAt,
             @Param("createdAt") Instant createdAt,

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/member/presenter/MemberPresenter.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/member/presenter/MemberPresenter.java
@@ -3,9 +3,11 @@ package com.callv2.drive.infrastructure.member.presenter;
 import com.callv2.drive.application.member.quota.request.list.ListRequestQuotaOutput;
 import com.callv2.drive.application.member.quota.retrieve.get.GetQuotaOutput;
 import com.callv2.drive.application.member.quota.retrieve.list.ListQuotaOutput;
+import com.callv2.drive.application.member.quota.retrieve.summary.GetQuotasSummaryOutput;
 import com.callv2.drive.infrastructure.member.model.MemberQuotaListResponse;
 import com.callv2.drive.infrastructure.member.model.MemberQuotaResponse;
 import com.callv2.drive.infrastructure.member.model.QuotaRequestListResponse;
+import com.callv2.drive.infrastructure.member.model.QuotaSummaryResponse;
 
 public interface MemberPresenter {
 
@@ -33,6 +35,14 @@ public interface MemberPresenter {
                 output.memberId(),
                 output.username(),
                 output.total());
+    }
+
+    static QuotaSummaryResponse present(final GetQuotasSummaryOutput output) {
+        return new QuotaSummaryResponse(
+                output.membersCount(),
+                output.totalAllocatedQuota(),
+                output.totalUsedQuota(),
+                output.totalAvailableQuota());
     }
 
 }


### PR DESCRIPTION
This pull request introduces a new feature to provide an aggregated summary of quota usage and allocation for members, along with several supporting changes and some minor naming corrections. The main focus is on implementing the quota summary use case, exposing it via the API, and updating the data access and domain layers to support the required statistics.

**Quota summary feature:**

* Added the `GetQuotasSummaryUseCase` abstract class and its implementation `DefaultGetQuotasSummaryUseCase`, which aggregates total members, total allocated quota, total used storage, and total available quota. (`application/src/main/java/com/callv2/drive/application/member/quota/retrieve/summary/GetQuotasSummaryUseCase.java` [[1]](diffhunk://#diff-c3200710a409feb2b4f47c8f3124cbe13ad33178df3ebd7a32f50714bbf6a07dR1-R7) `DefaultGetQuotasSummaryUseCase.java` [[2]](diffhunk://#diff-4114f76f76abcb8cd3f768b39de979ddd21d1c5a8d1937447c8f9d59d2e61aa3R1-R33)
* Introduced the output DTO `GetQuotasSummaryOutput` to encapsulate the summary data. (`GetQuotasSummaryOutput.java` [application/src/main/java/com/callv2/drive/application/member/quota/retrieve/summary/GetQuotasSummaryOutput.javaR1-R9](diffhunk://#diff-670da5a20dc5d3f5954f8a924318666f59fbb6e4fc2877d28d05a8615150d8dbR1-R9))
* Added the API endpoint `/admin/members/quotas/summary` to `MemberAdminAPI` and implemented it in `MemberAdminController`, returning a `QuotaSummaryResponse`. (`MemberAdminAPI.java` [[1]](diffhunk://#diff-ff9315202227c9a42496a21022efaa5998d882e993ec8c3b7908e61dd90e786cR70-R75) [[2]](diffhunk://#diff-a83074e73dacb0218c2418ac388ce678bceb4540a2d33ec6c79203ead96aeea1R102-R106); `QuotaSummaryResponse.java` [[3]](diffhunk://#diff-1258b05422f01c2c72a4a1294b292db398c4b16915880f1be2ab5511d0208964R1-R9)
* Registered the new use case bean in the configuration. (`MemberUseCaseConfig.java` [infrastructure/src/main/java/com/callv2/drive/infrastructure/configuration/usecase/MemberUseCaseConfig.javaR64-R68](diffhunk://#diff-82e9353021dbb14d7d9d2e02a34c83bfb043f344041b7adf08b9d9fe2c04de44R64-R68))

**Domain and persistence support for quota statistics:**

* Added `count()` and `sumAllQuota()` methods to `MemberGateway` and implemented them in `DefaultMemberGateway` and `MemberJpaRepository`. (`MemberGateway.java` [[1]](diffhunk://#diff-563a68bf8e1f6aefc123425a57bdd517b7d5173e9ac8419aa2479841497d8017R12-R13) [[2]](diffhunk://#diff-563a68bf8e1f6aefc123425a57bdd517b7d5173e9ac8419aa2479841497d8017R24-R25); `DefaultMemberGateway.java` [[3]](diffhunk://#diff-ad5dcf49c85084ae9c661202d03ecadd6da5a605972f5a436026a3c746c16078R45-R49) [[4]](diffhunk://#diff-ad5dcf49c85084ae9c661202d03ecadd6da5a605972f5a436026a3c746c16078R126-R130)
* Added `sumAllContentSize()` to `FileGateway` and implemented it in `FileJPAGateway` and `FileJpaRepository`. (`FileGateway.java` [[1]](diffhunk://#diff-ac47ddbeab42fe784df003a3537686bdb010896efe974817ef7dcad26ade8baeR25-R26) `FileJPAGateway.java` [[2]](diffhunk://#diff-99ceda3736e95a0e200edc1dbb17f79bf019cc0e14e56ee56e5e53c973d7a3b3R89-R93) `FileJpaRepository.java` [[3]](diffhunk://#diff-debb719ce31077c8b1d6945eb7a91d912862318b7f8a5dc943d89c04a57218e2R20-R22)

**API and naming consistency improvements:**

* Corrected the spelling of "ammount" to "amount" in DTOs, API descriptions, and entity fields for clarity and consistency. (`CreateRequestQuotaInput.java` [[1]](diffhunk://#diff-919e156f246dfe415c10f21e33c1a49e4bdb62f71fc44318c938364a2a57c54cL5-R5) `DefaultCreateRequestQuotaUseCase.java` [[2]](diffhunk://#diff-00291129d3c45906d4b1ddd7c532e5a83cc3419e15c0f0ecef4fa0d5f75bcad5L31-R31) `MemberAPI.java` [[3]](diffhunk://#diff-92f83d82039527e85b62de79acb0a18c65a35cb172612eeaad881026fd567bd4L24-R32) `MemberAdminAPI.java` [[4]](diffhunk://#diff-ff9315202227c9a42496a21022efaa5998d882e993ec8c3b7908e61dd90e786cL31-R38)
* Updated `MemberJpaEntity` and related code to use `quotaAmount`, `quotaInBytes`, and similar consistent field names. (`MemberJpaEntity.java` [[1]](diffhunk://#diff-7de80c84b145337c613aafc40e5ab058c8492db3575a028b22bea106420fd76cL32-R43) [[2]](diffhunk://#diff-7de80c84b145337c613aafc40e5ab058c8492db3575a028b22bea106420fd76cL58-R67) `DefaultMemberGateway.java` [[3]](diffhunk://#diff-ad5dcf49c85084ae9c661202d03ecadd6da5a605972f5a436026a3c746c16078L86-R93)

These changes collectively enable administrators to retrieve an overview of quota allocation and usage, and improve overall code clarity and maintainability.