### PR TITLE
feat: enhance file handling with storage key management and retrieval…

### DIFF
--- a/application/src/main/java/com/callv2/drive/application/file/content/get/DefaultGetFileContentUseCase.java
+++ b/application/src/main/java/com/callv2/drive/application/file/content/get/DefaultGetFileContentUseCase.java
@@ -6,13 +6,18 @@ import com.callv2.drive.domain.exception.NotFoundException;
 import com.callv2.drive.domain.file.File;
 import com.callv2.drive.domain.file.FileGateway;
 import com.callv2.drive.domain.file.FileID;
+import com.callv2.drive.domain.storage.StorageService;
 
 public class DefaultGetFileContentUseCase extends GetFileContentUseCase {
 
     private final FileGateway fileGateway;
+    private final StorageService storageService;
 
-    public DefaultGetFileContentUseCase(final FileGateway fileGateway) {
+    public DefaultGetFileContentUseCase(
+            final FileGateway fileGateway,
+            final StorageService storageService) {
         this.fileGateway = Objects.requireNonNull(fileGateway);
+        this.storageService = Objects.requireNonNull(storageService);
     }
 
     @Override
@@ -26,8 +31,9 @@ public class DefaultGetFileContentUseCase extends GetFileContentUseCase {
 
         return GetFileContentOutput.with(
                 file.getName().value(),
-                file.getContent().location(),
-                file.getContent().size());
+                file.getContent().size(),
+                storageService.retrieve(file.getContent().storageKey()));
+
     }
 
 }

--- a/application/src/main/java/com/callv2/drive/application/file/content/get/GetFileContentOutput.java
+++ b/application/src/main/java/com/callv2/drive/application/file/content/get/GetFileContentOutput.java
@@ -1,9 +1,11 @@
 package com.callv2.drive.application.file.content.get;
 
-public record GetFileContentOutput(String name, String location, long size) {
+import java.io.InputStream;
 
-    public static GetFileContentOutput with(final String name, final String location, final long size) {
-        return new GetFileContentOutput(name, location, size);
+public record GetFileContentOutput(String name, long size, InputStream inputStream) {
+
+    public static GetFileContentOutput with(final String name, final long size, InputStream inputStream) {
+        return new GetFileContentOutput(name, size, inputStream);
     }
 
 }

--- a/application/src/main/java/com/callv2/drive/application/file/delete/DefaultDeleteFileUseCase.java
+++ b/application/src/main/java/com/callv2/drive/application/file/delete/DefaultDeleteFileUseCase.java
@@ -43,7 +43,7 @@ public class DefaultDeleteFileUseCase extends DeleteFileUseCase {
                 .orElseThrow(() -> NotFoundException.with(File.class, input.fileId().toString()));
 
         fileGateway.deleteById(file.getId()); // TODO maybe needs transactional
-        deleteContentFile(file.getContent().location());
+        deleteContentFile(file.getContent().storageKey());
     }
 
     private void deleteContentFile(final String contentLocation) {

--- a/application/src/test/java/com/callv2/drive/application/file/content/get/DefaultGetFileContentUseCaseTest.java
+++ b/application/src/test/java/com/callv2/drive/application/file/content/get/DefaultGetFileContentUseCaseTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.io.ByteArrayInputStream;
 import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
@@ -24,6 +25,7 @@ import com.callv2.drive.domain.file.FileID;
 import com.callv2.drive.domain.file.FileName;
 import com.callv2.drive.domain.folder.FolderID;
 import com.callv2.drive.domain.member.MemberID;
+import com.callv2.drive.domain.storage.StorageService;
 
 @ExtendWith(MockitoExtension.class)
 public class DefaultGetFileContentUseCaseTest {
@@ -34,26 +36,33 @@ public class DefaultGetFileContentUseCaseTest {
     @Mock
     FileGateway fileGateway;
 
+    @Mock
+    StorageService storageService;
+
     @Test
     void givenAValidParam_whenCallsExecute_shouldReturnContent() {
 
         final var ownerId = MemberID.of("owner");
         final var expectedFolder = FolderID.unique();
         final var expectedFileName = FileName.of("file.txt");
-        final var expectedContent = Content.of("location", "text", 10);
+        final var expectedContent = Content.of("key", "text", 10);
         final var expectedFile = File.create(ownerId, expectedFolder, expectedFileName, expectedContent);
         final var expectedFileId = expectedFile.getId();
+        final var expectedInputStream = new ByteArrayInputStream(new byte[] {});
 
         when(fileGateway.findById(any()))
                 .thenReturn(Optional.of(expectedFile));
+
+        when(storageService.retrieve(expectedContent.storageKey()))
+                .thenReturn(expectedInputStream);
 
         final var input = GetFileContentInput.with(expectedFileId.getValue());
 
         final var actualOutput = useCase.execute(input);
 
         assertEquals(expectedFileName.value(), actualOutput.name());
-        assertEquals(expectedContent.location(), actualOutput.location());
         assertEquals(expectedContent.size(), actualOutput.size());
+        assertEquals(expectedInputStream, actualOutput.inputStream());
 
         verify(fileGateway, times(1)).findById(any());
         verify(fileGateway, times(1)).findById(eq(expectedFileId));

--- a/application/src/test/java/com/callv2/drive/application/file/create/DefaultCreateFileUseCaseTest.java
+++ b/application/src/test/java/com/callv2/drive/application/file/create/DefaultCreateFileUseCaseTest.java
@@ -45,7 +45,7 @@ import com.callv2.drive.domain.member.Username;
 import com.callv2.drive.domain.storage.StorageService;
 
 @ExtendWith(MockitoExtension.class)
-public class DefaultCreateFileUseCaseTest {
+class DefaultCreateFileUseCaseTest {
 
     @InjectMocks
     DefaultCreateFileUseCase useCase;
@@ -99,8 +99,8 @@ public class DefaultCreateFileUseCaseTest {
         when(folderGateway.findById(any()))
                 .thenReturn(Optional.of(folder));
 
-        when(storageService.store(any(), any()))
-                .then(returnsFirstArg());
+        doNothing()
+                .when(storageService).store(any(), any());
 
         when(fileGateway.create(any()))
                 .thenAnswer(returnsFirstArg());
@@ -132,7 +132,7 @@ public class DefaultCreateFileUseCaseTest {
             assertEquals(expectedContentType, file.getContent().type());
             assertNotNull(file.getCreatedAt());
             assertNotNull(file.getUpdatedAt());
-            assertNotNull(file.getContent().location());
+            assertNotNull(file.getContent().storageKey());
             assertEquals(file.getCreatedAt(), file.getUpdatedAt());
 
             return true;
@@ -356,8 +356,8 @@ public class DefaultCreateFileUseCaseTest {
         when(folderGateway.findById(any()))
                 .thenReturn(Optional.of(folder));
 
-        when(storageService.store(any(), any()))
-                .then(returnsFirstArg());
+        doNothing()
+                .when(storageService).store(any(), any());
 
         when(fileGateway.create(any()))
                 .thenThrow(new IllegalStateException("FileGateway Exception"));
@@ -394,7 +394,7 @@ public class DefaultCreateFileUseCaseTest {
             assertEquals(expectedContentType, file.getContent().type());
             assertNotNull(file.getCreatedAt());
             assertNotNull(file.getUpdatedAt());
-            assertNotNull(file.getContent().location());
+            assertNotNull(file.getContent().storageKey());
             assertEquals(file.getCreatedAt(), file.getUpdatedAt());
 
             return true;
@@ -441,8 +441,8 @@ public class DefaultCreateFileUseCaseTest {
         when(folderGateway.findById(any()))
                 .thenReturn(Optional.of(folder));
 
-        when(storageService.store(any(), any()))
-                .then(returnsFirstArg());
+        doNothing()
+                .when(storageService).store(any(), any());
 
         when(fileGateway.create(any()))
                 .thenThrow(new IllegalStateException("FileGateway Exception"));
@@ -479,7 +479,7 @@ public class DefaultCreateFileUseCaseTest {
             assertEquals(expectedContentType, file.getContent().type());
             assertNotNull(file.getCreatedAt());
             assertNotNull(file.getUpdatedAt());
-            assertNotNull(file.getContent().location());
+            assertNotNull(file.getContent().storageKey());
             assertEquals(file.getCreatedAt(), file.getUpdatedAt());
 
             return true;
@@ -523,8 +523,9 @@ public class DefaultCreateFileUseCaseTest {
         when(folderGateway.findById(any()))
                 .thenReturn(Optional.of(folder));
 
-        when(storageService.store(any(), any()))
-                .thenThrow(new IllegalStateException("ContentGateway Exception"));
+        doThrow(new IllegalStateException("ContentGateway Exception"))
+                .when(storageService)
+                .store(any(), any());
 
         final var input = CreateFileInput.of(
                 ownerId.getValue(),
@@ -709,8 +710,8 @@ public class DefaultCreateFileUseCaseTest {
         when(folderGateway.findById(any()))
                 .thenReturn(Optional.of(folder));
 
-        when(storageService.store(any(), any()))
-                .then(returnsFirstArg());
+        doNothing()
+                .when(storageService).store(any(), any());
 
         final var input = CreateFileInput.of(
                 ownerId.getValue(),

--- a/application/src/test/java/com/callv2/drive/application/file/delete/DefaultDeleteFileUseCaseTest.java
+++ b/application/src/test/java/com/callv2/drive/application/file/delete/DefaultDeleteFileUseCaseTest.java
@@ -105,7 +105,7 @@ public class DefaultDeleteFileUseCaseTest {
         verify(fileGateway, times(1)).deleteById(any());
         verify(fileGateway, times(1)).deleteById(eq(expectedFileId));
         verify(storageService, times(1)).delete(any());
-        verify(storageService, times(1)).delete(eq(expectedContent.location()));
+        verify(storageService, times(1)).delete(eq(expectedContent.storageKey()));
     }
 
     @Test

--- a/domain/src/main/java/com/callv2/drive/domain/exception/StorageKeyAlreadyExistsException.java
+++ b/domain/src/main/java/com/callv2/drive/domain/exception/StorageKeyAlreadyExistsException.java
@@ -1,0 +1,16 @@
+package com.callv2.drive.domain.exception;
+
+import java.util.List;
+
+public class StorageKeyAlreadyExistsException extends SilentDomainException {
+
+    private StorageKeyAlreadyExistsException(final String key) {
+        super("storage key [%s] already exists.".formatted(key),
+                List.of(DomainException.Error.with("storage key [%s] already exists.".formatted(key))));
+    }
+
+    public static StorageKeyAlreadyExistsException with(final String key) {
+        return new StorageKeyAlreadyExistsException(key);
+    }
+
+}

--- a/domain/src/main/java/com/callv2/drive/domain/file/Content.java
+++ b/domain/src/main/java/com/callv2/drive/domain/file/Content.java
@@ -4,25 +4,25 @@ import com.callv2.drive.domain.ValueObject;
 import com.callv2.drive.domain.validation.ValidationHandler;
 import com.callv2.drive.domain.validation.ValidationError;
 
-public record Content(String location, String type, long size) implements ValueObject {
+public record Content(String storageKey, String type, long size) implements ValueObject {
 
-    public static Content of(final String location, final String type, final long size) {
-        return new Content(location, type, size);
+    public static Content of(final String storageKey, final String type, final long size) {
+        return new Content(storageKey, type, size);
     }
 
     @Override
     public void validate(final ValidationHandler aHandler) {
-        validateLocation(aHandler);
+        validateStorageKey(aHandler);
         validateType(aHandler);
     }
 
-    private void validateLocation(final ValidationHandler aHandler) {
-        if (location == null) {
-            aHandler.append(new ValidationError("'location' cannot be null."));
+    private void validateStorageKey(final ValidationHandler aHandler) {
+        if (storageKey == null) {
+            aHandler.append(new ValidationError("'storageKey' cannot be null."));
             return;
         }
 
-        if (location.trim().isEmpty()) {
+        if (storageKey.trim().isEmpty()) {
             aHandler.append(new ValidationError("'location' cannot be empty."));
             return;
         }

--- a/domain/src/main/java/com/callv2/drive/domain/storage/StorageService.java
+++ b/domain/src/main/java/com/callv2/drive/domain/storage/StorageService.java
@@ -4,8 +4,10 @@ import java.io.InputStream;
 
 public interface StorageService {
 
-    String store(String name, InputStream content);
+    void store(String key, InputStream content);
 
-    void delete(String name);
+    void delete(String key);
+
+    InputStream retrieve(String key);
 
 }

--- a/domain/src/test/java/com/callv2/drive/domain/file/FileTest.java
+++ b/domain/src/test/java/com/callv2/drive/domain/file/FileTest.java
@@ -35,7 +35,7 @@ public class FileTest {
         assertEquals(expectedOwner, actualFile.getOwner());
         assertEquals(expectedName, actualFile.getName().value());
         assertEquals(expectedContentType, actualFile.getContent().type());
-        assertEquals(expectedContentLocation, actualFile.getContent().location());
+        assertEquals(expectedContentLocation, actualFile.getContent().storageKey());
         assertEquals(expectedContentSize, actualFile.getContent().size());
         assertNotNull(actualFile.getCreatedAt());
         assertNotNull(actualFile.getUpdatedAt());
@@ -218,7 +218,7 @@ public class FileTest {
 
         assertEquals(expectedName, actualUpdatedFile.getName());
         assertEquals(expectedContentType, actualUpdatedFile.getContent().type());
-        assertEquals(expectedContentLocation, actualUpdatedFile.getContent().location());
+        assertEquals(expectedContentLocation, actualUpdatedFile.getContent().storageKey());
         assertEquals(expectedContentSize, actualUpdatedFile.getContent().size());
         assertNotNull(actualUpdatedFile.getCreatedAt());
         assertNotNull(actualUpdatedFile.getUpdatedAt());

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/api/controller/FileController.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/api/controller/FileController.java
@@ -4,7 +4,7 @@ import java.net.URI;
 import java.util.List;
 import java.util.UUID;
 
-import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.InputStreamResource;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -17,8 +17,8 @@ import com.callv2.drive.application.file.content.get.GetFileContentInput;
 import com.callv2.drive.application.file.content.get.GetFileContentOutput;
 import com.callv2.drive.application.file.content.get.GetFileContentUseCase;
 import com.callv2.drive.application.file.create.CreateFileUseCase;
-import com.callv2.drive.application.file.delete.DeleteFileUseCase;
 import com.callv2.drive.application.file.delete.DeleteFileInput;
+import com.callv2.drive.application.file.delete.DeleteFileUseCase;
 import com.callv2.drive.application.file.retrieve.get.GetFileInput;
 import com.callv2.drive.application.file.retrieve.get.GetFileUseCase;
 import com.callv2.drive.application.file.retrieve.list.ListFilesUseCase;
@@ -95,7 +95,7 @@ public class FileController implements FileAPI {
                 .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + output.name() + "\"")
                 .contentLength(output.size())
                 .contentType(MediaType.APPLICATION_OCTET_STREAM)
-                .body(new FileSystemResource(output.location()));
+                .body(new InputStreamResource(output.inputStream()));
     }
 
     @Override

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/configuration/usecase/FileUseCaseConfig.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/configuration/usecase/FileUseCaseConfig.java
@@ -54,7 +54,7 @@ public class FileUseCaseConfig {
 
     @Bean
     GetFileContentUseCase getFileContentUseCase() {
-        return new DefaultGetFileContentUseCase(fileGateway);
+        return new DefaultGetFileContentUseCase(fileGateway, storageService);
     }
 
     @Bean

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/file/persistence/FileJpaEntity.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/file/persistence/FileJpaEntity.java
@@ -34,8 +34,8 @@ public class FileJpaEntity {
     @Column(name = "content_type", nullable = false)
     private String contentType;
 
-    @Column(name = "content_location", nullable = false)
-    private String contentLocation;
+    @Column(name = "content_storage_key", nullable = false)
+    private String contentStorageKey;
 
     @Column(name = "content_size", nullable = false)
     private Long contentSize;
@@ -61,7 +61,7 @@ public class FileJpaEntity {
         this.folderId = folderId;
         this.name = name;
         this.contentType = contentType;
-        this.contentLocation = contentLocation;
+        this.contentStorageKey = contentLocation;
         this.contentSize = contentSize;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
@@ -77,7 +77,7 @@ public class FileJpaEntity {
                 file.getFolder().getValue(),
                 file.getName().value(),
                 file.getContent().type(),
-                file.getContent().location(),
+                file.getContent().storageKey(),
                 file.getContent().size(),
                 file.getCreatedAt(),
                 file.getUpdatedAt());
@@ -89,7 +89,7 @@ public class FileJpaEntity {
                 MemberID.of(getOwnerId()),
                 FolderID.of(getFolderId()),
                 FileName.of(getName()),
-                Content.of(getContentLocation(), getContentType(), getContentSize()),
+                Content.of(getContentStorageKey(), getContentType(), getContentSize()),
                 getCreatedAt(),
                 getUpdatedAt());
     }
@@ -134,12 +134,12 @@ public class FileJpaEntity {
         this.contentType = contentType;
     }
 
-    public String getContentLocation() {
-        return contentLocation;
+    public String getContentStorageKey() {
+        return contentStorageKey;
     }
 
-    public void setContentLocation(String contentLocation) {
-        this.contentLocation = contentLocation;
+    public void setContentStorageKey(String contentStorageKey) {
+        this.contentStorageKey = contentStorageKey;
     }
 
     public Long getContentSize() {
@@ -169,7 +169,7 @@ public class FileJpaEntity {
     @Override
     public String toString() {
         return "FileJpaEntity [id=" + id + ", ownerId=" + ownerId + ", folderId=" + folderId + ", name=" + name
-                + ", contentType=" + contentType + ", contentLocation=" + contentLocation + ", contentSize="
+                + ", contentType=" + contentType + ", contentStorageKey=" + contentStorageKey + ", contentSize="
                 + contentSize + ", createdAt=" + createdAt + ", updatedAt=" + updatedAt + "]";
     }
 


### PR DESCRIPTION
This pull request introduces significant changes to how file content is managed and retrieved in the application. The main update is the transition from using a file "location" string to a "storageKey" for identifying file content, and the adoption of streaming file content via `InputStream` rather than returning a location. This impacts the domain model, application use cases, service interfaces, and related tests. Additionally, the storage service interface is updated to support retrieving content streams, and a new exception is introduced for duplicate storage keys.

**Domain model and API changes:**

* The `Content` value object now uses `storageKey` instead of `location`, and all validation, construction, and usage have been updated accordingly.
* The `GetFileContentOutput` now returns an `InputStream` for file content instead of a location string, reflecting a shift to direct streaming of file content.

**Application/service layer changes:**

* `DefaultGetFileContentUseCase` and related logic now use `storageKey` and retrieve file content via `StorageService.retrieve`, returning an `InputStream` to the caller. [[1]](diffhunk://#diff-cd729991997807230b871367af44b75081b32d4c3dfa95628f827f404cd6ccfcR9-R20) [[2]](diffhunk://#diff-cd729991997807230b871367af44b75081b32d4c3dfa95628f827f404cd6ccfcL29-R36)
* The `StorageService` interface has been updated: `store` now returns void and throws if the key exists, `delete` and `retrieve` operate on `storageKey`.
* The file creation flow now generates a random `storageKey`, retries if a key already exists (using the new `StorageKeyAlreadyExistsException`), and stores content under that key. [[1]](diffhunk://#diff-a4fafd915d541ac669c652b8f4eba69bbf734f8b65c18ad9d6b42ba1ae40b328L80-R85) [[2]](diffhunk://#diff-a4fafd915d541ac669c652b8f4eba69bbf734f8b65c18ad9d6b42ba1ae40b328L100-R124) [[3]](diffhunk://#diff-e0285775273c4178cf68e368ee9e806b44922b683a8f6db7b33f7cb466855aedR1-R16)

**Testing and validation:**

* All affected tests have been updated to use `storageKey` instead of `location`, and to verify streaming content via `InputStream`. [[1]](diffhunk://#diff-35dcc114e68678c850d93990f5b445a52d81ca74895cecbd0867cc712028b4fcR28) [[2]](diffhunk://#diff-35dcc114e68678c850d93990f5b445a52d81ca74895cecbd0867cc712028b4fcR39-R65) [[3]](diffhunk://#diff-1aa78b9ffd6c3fb15604e1fab12a5c066985eaef4bcd3249b06bebc1a687e3caL135-R135) [[4]](diffhunk://#diff-d5abb3602c61e8e08083d109414742d1901a11c63625acb94c8c3abd2a9e45edL38-R38) [[5]](diffhunk://#diff-d5abb3602c61e8e08083d109414742d1901a11c63625acb94c8c3abd2a9e45edL221-R221) [[6]](diffhunk://#diff-ed9665130c106ffcb0402bab2fdbfaec621add4ddd41d71b76a448b9fe6375d7L108-R108)
* Mocking and assertions in tests have been adapted for the new service interface and content retrieval method. [[1]](diffhunk://#diff-35dcc114e68678c850d93990f5b445a52d81ca74895cecbd0867cc712028b4fcR28) [[2]](diffhunk://#diff-35dcc114e68678c850d93990f5b445a52d81ca74895cecbd0867cc712028b4fcR39-R65) [[3]](diffhunk://#diff-1aa78b9ffd6c3fb15604e1fab12a5c066985eaef4bcd3249b06bebc1a687e3caL102-R103) [[4]](diffhunk://#diff-1aa78b9ffd6c3fb15604e1fab12a5c066985eaef4bcd3249b06bebc1a687e3caL135-R135) [[5]](diffhunk://#diff-1aa78b9ffd6c3fb15604e1fab12a5c066985eaef4bcd3249b06bebc1a687e3caL359-R360) [[6]](diffhunk://#diff-1aa78b9ffd6c3fb15604e1fab12a5c066985eaef4bcd3249b06bebc1a687e3caL397-R397) [[7]](diffhunk://#diff-1aa78b9ffd6c3fb15604e1fab12a5c066985eaef4bcd3249b06bebc1a687e3caL444-R445) [[8]](diffhunk://#diff-1aa78b9ffd6c3fb15604e1fab12a5c066985eaef4bcd3249b06bebc1a687e3caL482-R482) [[9]](diffhunk://#diff-1aa78b9ffd6c3fb15604e1fab12a5c066985eaef4bcd3249b06bebc1a687e3caL526-R528) [[10]](diffhunk://#diff-1aa78b9ffd6c3fb15604e1fab12a5c066985eaef4bcd3249b06bebc1a687e3caL712-R714)

**Infrastructure/API changes:**

* The API controller now uses `InputStreamResource` instead of `FileSystemResource` to serve file content streams.

**Exception handling:**

* Introduced `StorageKeyAlreadyExistsException` to handle rare key collisions when storing content.