### PR TITLE
fix: member update

### DIFF
--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/member/DefaultMemberGateway.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/member/DefaultMemberGateway.java
@@ -88,18 +88,21 @@ public class DefaultMemberGateway implements MemberGateway {
                 memberJpa.getId(),
                 memberJpa.getUsername(),
                 memberJpa.getNickname(),
+                memberJpa.getQuotaInBytes(),
                 memberJpa.getQuotaAmount(),
                 memberJpa.getQuotaUnit(),
+                memberJpa.getQuotaRequestInBytes(),
                 memberJpa.getQuotaRequestAmount(),
                 memberJpa.getQuotaRequestUnit(),
                 memberJpa.getQuotaRequestedAt(),
+                memberJpa.getHasSystemAccess(),
                 memberJpa.getCreatedAt(),
                 memberJpa.getUpdatedAt(),
                 memberJpa.getSynchronizedVersion());
 
         if (rowsUpdated != 1)
             throw new OptimisticLockingFailureException(
-                    "Member update failed due to version conflict for id: " + member.getId().getValue());
+                    "Member update failed due to SynchronizedVersion conflict for id: " + member.getId().getValue());
 
         return member;
     }

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/member/persistence/MemberJpaRepository.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/member/persistence/MemberJpaRepository.java
@@ -38,26 +38,32 @@ public interface MemberJpaRepository extends JpaRepository<MemberJpaEntity, Stri
             set
                 m.username = :username,
                 m.nickname = :nickname,
+                m.quotaInBytes = :quotaInBytes,
                 m.quotaAmount = :quotaAmount,
                 m.quotaUnit = :quotaUnit,
+                m.quotaRequestInBytes = :quotaRequestInBytes,
                 m.quotaRequestAmount = :quotaRequestAmount,
                 m.quotaRequestUnit = :quotaRequestUnit,
                 m.quotaRequestedAt = :quotaRequestedAt,
+                m.hasSystemAccess = :hasSystemAccess,
                 m.createdAt = :createdAt,
                 m.updatedAt = :updatedAt,
                 m.synchronizedVersion = :synchronizedVersion
             where m.id = :id
-            and (m.synchronizedVersion is null or :synchronizedVersion > m.synchronizedVersion)
+            and (m.synchronizedVersion is null or :synchronizedVersion >= m.synchronizedVersion)
             """)
     Integer update(
             @Param("id") String id,
             @Param("username") String username,
             @Param("nickname") String nickname,
+            @Param("quotaInBytes") Long quotaInBytes,
             @Param("quotaAmount") Long quotaAmount,
             @Param("quotaUnit") QuotaUnit quotaUnit,
+            @Param("quotaRequestInBytes") Long quotaRequestInBytes,
             @Param("quotaRequestAmount") Long quotaRequestAmount,
             @Param("quotaRequestUnit") QuotaUnit quotaRequestUnit,
             @Param("quotaRequestedAt") Instant quotaRequestedAt,
+            @Param("hasSystemAccess") Boolean hasSystemAccess,
             @Param("createdAt") Instant createdAt,
             @Param("updatedAt") Instant updatedAt,
             @Param("synchronizedVersion") Long synchronizedVersion);


### PR DESCRIPTION
This pull request updates the member update logic in the persistence layer to support additional fields and improve version conflict handling. The main changes add new member attributes to the update process and relax the optimistic locking condition to allow updates when the synchronized version is equal.

Persistence and update logic improvements:

* Added support for the following new fields in member updates: `quotaInBytes`, `quotaRequestInBytes`, and `hasSystemAccess` in both the `DefaultMemberGateway` and `MemberJpaRepository` (`DefaultMemberGateway.java`, `MemberJpaRepository.java`). [[1]](diffhunk://#diff-ad5dcf49c85084ae9c661202d03ecadd6da5a605972f5a436026a3c746c16078R91-R105) [[2]](diffhunk://#diff-fb09fc39b33907c94685a89e9cadb3b5d201a468bd257aad72fbd36cc89b98c4R41-R66)
* Relaxed the optimistic locking condition in the update query to allow updates when `synchronizedVersion` is equal to the current value, not just greater (`MemberJpaRepository.java`).
* Updated the exception message in `DefaultMemberGateway` to clarify that the conflict is related to `SynchronizedVersion` (`DefaultMemberGateway.java`).