### PR TITLE
Feature/resource access control

### DIFF
--- a/application/src/main/java/com/callv2/drive/application/file/content/delete/DefaultlDeleteFileContentUseCase.java
+++ b/application/src/main/java/com/callv2/drive/application/file/content/delete/DefaultlDeleteFileContentUseCase.java
@@ -3,16 +3,16 @@ package com.callv2.drive.application.file.content.delete;
 import com.callv2.drive.domain.file.File;
 import com.callv2.drive.domain.file.FileGateway;
 import com.callv2.drive.domain.file.FileID;
-import com.callv2.drive.domain.storage.StorageService;
+import com.callv2.drive.domain.storage.StorageGateway;
 
 public class DefaultlDeleteFileContentUseCase extends DeleteFileContentUseCase {
 
     private final FileGateway fileGateway;
-    private final StorageService storageService;
+    private final StorageGateway storageService;
 
     public DefaultlDeleteFileContentUseCase(
             FileGateway fileGateway,
-            StorageService storageService) {
+            StorageGateway storageService) {
         this.fileGateway = fileGateway;
         this.storageService = storageService;
     }

--- a/application/src/main/java/com/callv2/drive/application/file/content/delete/DefaultlDeleteFileContentUseCase.java
+++ b/application/src/main/java/com/callv2/drive/application/file/content/delete/DefaultlDeleteFileContentUseCase.java
@@ -3,6 +3,7 @@ package com.callv2.drive.application.file.content.delete;
 import com.callv2.drive.domain.file.File;
 import com.callv2.drive.domain.file.FileGateway;
 import com.callv2.drive.domain.file.FileID;
+import com.callv2.drive.domain.member.MemberID;
 import com.callv2.drive.domain.storage.StorageGateway;
 
 public class DefaultlDeleteFileContentUseCase extends DeleteFileContentUseCase {
@@ -21,7 +22,7 @@ public class DefaultlDeleteFileContentUseCase extends DeleteFileContentUseCase {
     public void execute(final DeleteFileContentInput input) {
 
         fileGateway
-                .findById(FileID.of(input.id()))
+                .findByIdWithMemberAccess(FileID.of(input.fileId()), MemberID.of(input.deleterId()))
                 .ifPresent(this::fullFileDeletion);
 
     }

--- a/application/src/main/java/com/callv2/drive/application/file/content/delete/DeleteFileContentInput.java
+++ b/application/src/main/java/com/callv2/drive/application/file/content/delete/DeleteFileContentInput.java
@@ -2,10 +2,10 @@ package com.callv2.drive.application.file.content.delete;
 
 import java.util.UUID;
 
-public record DeleteFileContentInput(UUID id) {
+public record DeleteFileContentInput(UUID fileId, UUID deleterId) {
 
-    public static DeleteFileContentInput of(UUID id) {
-        return new DeleteFileContentInput(id);
+    public static DeleteFileContentInput of(final UUID fileId, final UUID deleterId) {
+        return new DeleteFileContentInput(fileId, deleterId);
     }
 
 }

--- a/application/src/main/java/com/callv2/drive/application/file/content/get/DefaultGetFileContentUseCase.java
+++ b/application/src/main/java/com/callv2/drive/application/file/content/get/DefaultGetFileContentUseCase.java
@@ -6,6 +6,7 @@ import com.callv2.drive.domain.exception.NotFoundException;
 import com.callv2.drive.domain.file.File;
 import com.callv2.drive.domain.file.FileGateway;
 import com.callv2.drive.domain.file.FileID;
+import com.callv2.drive.domain.member.MemberID;
 import com.callv2.drive.domain.storage.StorageGateway;
 
 public class DefaultGetFileContentUseCase extends GetFileContentUseCase {
@@ -24,9 +25,10 @@ public class DefaultGetFileContentUseCase extends GetFileContentUseCase {
     public GetFileContentOutput execute(GetFileContentInput input) {
 
         final FileID fileId = FileID.of(input.fileId());
+        final MemberID actorId = MemberID.of(input.actorId());
 
         final File file = fileGateway
-                .findById(fileId)
+                .findByIdWithMemberAccess(fileId, actorId)
                 .orElseThrow(() -> NotFoundException.with(File.class, input.fileId().toString()));
 
         return GetFileContentOutput.with(

--- a/application/src/main/java/com/callv2/drive/application/file/content/get/DefaultGetFileContentUseCase.java
+++ b/application/src/main/java/com/callv2/drive/application/file/content/get/DefaultGetFileContentUseCase.java
@@ -6,16 +6,16 @@ import com.callv2.drive.domain.exception.NotFoundException;
 import com.callv2.drive.domain.file.File;
 import com.callv2.drive.domain.file.FileGateway;
 import com.callv2.drive.domain.file.FileID;
-import com.callv2.drive.domain.storage.StorageService;
+import com.callv2.drive.domain.storage.StorageGateway;
 
 public class DefaultGetFileContentUseCase extends GetFileContentUseCase {
 
     private final FileGateway fileGateway;
-    private final StorageService storageService;
+    private final StorageGateway storageService;
 
     public DefaultGetFileContentUseCase(
             final FileGateway fileGateway,
-            final StorageService storageService) {
+            final StorageGateway storageService) {
         this.fileGateway = Objects.requireNonNull(fileGateway);
         this.storageService = Objects.requireNonNull(storageService);
     }

--- a/application/src/main/java/com/callv2/drive/application/file/content/get/GetFileContentInput.java
+++ b/application/src/main/java/com/callv2/drive/application/file/content/get/GetFileContentInput.java
@@ -2,10 +2,10 @@ package com.callv2.drive.application.file.content.get;
 
 import java.util.UUID;
 
-public record GetFileContentInput(UUID fileId) {
+public record GetFileContentInput(UUID fileId, UUID actorId) {
 
-    public static GetFileContentInput with(final UUID fileId) {
-        return new GetFileContentInput(fileId);
+    public static GetFileContentInput with(final UUID fileId, final UUID actorId) {
+        return new GetFileContentInput(fileId, actorId);
     }
 
 }

--- a/application/src/main/java/com/callv2/drive/application/file/create/CreateFileInput.java
+++ b/application/src/main/java/com/callv2/drive/application/file/create/CreateFileInput.java
@@ -3,17 +3,22 @@ package com.callv2.drive.application.file.create;
 import java.io.InputStream;
 import java.util.UUID;
 
-public record CreateFileInput(UUID ownerId, UUID folderId, String name, String contentType, InputStream content,
+public record CreateFileInput(
+        UUID creatorId,
+        UUID folderId,
+        String name,
+        String contentType,
+        InputStream content,
         long size) {
 
     public static CreateFileInput of(
-            final UUID ownerId,
+            final UUID creatorId,
             final UUID folderId,
             final String name,
             final String contentType,
             final InputStream content,
             final long size) {
-        return new CreateFileInput(ownerId, folderId, name, contentType, content, size);
+        return new CreateFileInput(creatorId, folderId, name, contentType, content, size);
     }
 
 }

--- a/application/src/main/java/com/callv2/drive/application/file/create/CreateFileInput.java
+++ b/application/src/main/java/com/callv2/drive/application/file/create/CreateFileInput.java
@@ -3,11 +3,11 @@ package com.callv2.drive.application.file.create;
 import java.io.InputStream;
 import java.util.UUID;
 
-public record CreateFileInput(String ownerId, UUID folderId, String name, String contentType, InputStream content,
+public record CreateFileInput(UUID ownerId, UUID folderId, String name, String contentType, InputStream content,
         long size) {
 
     public static CreateFileInput of(
-            final String ownerId,
+            final UUID ownerId,
             final UUID folderId,
             final String name,
             final String contentType,

--- a/application/src/main/java/com/callv2/drive/application/file/create/DefaultCreateFileUseCase.java
+++ b/application/src/main/java/com/callv2/drive/application/file/create/DefaultCreateFileUseCase.java
@@ -93,12 +93,12 @@ public class DefaultCreateFileUseCase extends CreateFileUseCase {
         if (notification.hasError())
             throw ValidationException.with("Could not create Aggregate File", notification);
 
-        final List<File> filesOnSameFolder = fileGateway.findByFolder(folderId);
+        final List<File> filesOnSameFolder = fileGateway.findAllActiveByFolder(folderId);
         if (filesOnSameFolder.stream().map(File::getName).anyMatch(fileName::equals))
             throw ValidationException.with("Could not create Aggregate File",
                     ValidationError.with("File with same name already exists on this folder"));
 
-        final Content content = storeContentFile(input);//TODO handle exception and delete content if necessary
+        final Content content = storeContentFile(input);// TODO handle exception and delete content if necessary
 
         final File file = notification
                 .validate(() -> File.create(creatorId, folder.getOwner(), folderId, fileName, content));

--- a/application/src/main/java/com/callv2/drive/application/file/create/DefaultCreateFileUseCase.java
+++ b/application/src/main/java/com/callv2/drive/application/file/create/DefaultCreateFileUseCase.java
@@ -9,6 +9,7 @@ import com.callv2.drive.domain.access.AclGateway;
 import com.callv2.drive.domain.access.Resource;
 import com.callv2.drive.domain.event.EventDispatcher;
 import com.callv2.drive.domain.exception.InternalErrorException;
+import com.callv2.drive.domain.exception.NotAllowedException;
 import com.callv2.drive.domain.exception.NotFoundException;
 import com.callv2.drive.domain.exception.QuotaExceededException;
 import com.callv2.drive.domain.exception.ValidationException;
@@ -70,9 +71,14 @@ public class DefaultCreateFileUseCase extends CreateFileUseCase {
 
         final Acl folderAcl = this.aclGateway
                 .findByResource(Resource.folder(folderId))
-                .orElseThrow();// TODO throw some exception
+                .orElseThrow(() -> NotFoundException.with(Folder.class, input.folderId().toString()));
 
-        checkAccessPermission(creatorId, folderAcl);
+        final AccessPermission folderAclPermission = folderAcl
+                .effectiveAccessPermission(creatorId)
+                .orElseThrow(() -> NotFoundException.with(Folder.class, input.folderId().toString()));
+
+        if (!folderAclPermission.canWrite())
+            throw NotAllowedException.with("You don't have permission to create files in this folder");
 
         final Member owner = memberGateway
                 .findById(folder.getOwner())
@@ -108,17 +114,6 @@ public class DefaultCreateFileUseCase extends CreateFileUseCase {
         eventDispatcher.notify(file);
 
         return CreateFileOutput.from(file);
-    }
-
-    private void checkAccessPermission(final MemberID memberId, final Acl folderAcl) {
-
-        final AccessPermission folderAclPermission = folderAcl
-                .effectiveAccessPermission(memberId)
-                .orElseThrow();// TODO throw some exception
-
-        if (!folderAclPermission.canWrite())
-            throw new RuntimeException("You don't have permission to create files in this folder");// TODO domain
-
     }
 
     private void checkQuota(final Member owner, final Long newFileSize) {

--- a/application/src/main/java/com/callv2/drive/application/file/create/DefaultCreateFileUseCase.java
+++ b/application/src/main/java/com/callv2/drive/application/file/create/DefaultCreateFileUseCase.java
@@ -98,7 +98,7 @@ public class DefaultCreateFileUseCase extends CreateFileUseCase {
             throw ValidationException.with("Could not create Aggregate File",
                     ValidationError.with("File with same name already exists on this folder"));
 
-        final Content content = storeContentFile(input);
+        final Content content = storeContentFile(input);//TODO handle exception and delete content if necessary
 
         final File file = notification
                 .validate(() -> File.create(creatorId, folder.getOwner(), folderId, fileName, content));

--- a/application/src/main/java/com/callv2/drive/application/file/create/DefaultCreateFileUseCase.java
+++ b/application/src/main/java/com/callv2/drive/application/file/create/DefaultCreateFileUseCase.java
@@ -7,6 +7,7 @@ import com.callv2.drive.domain.access.AccessPermission;
 import com.callv2.drive.domain.access.Acl;
 import com.callv2.drive.domain.access.AclGateway;
 import com.callv2.drive.domain.access.Resource;
+import com.callv2.drive.domain.event.EventDispatcher;
 import com.callv2.drive.domain.exception.InternalErrorException;
 import com.callv2.drive.domain.exception.NotFoundException;
 import com.callv2.drive.domain.exception.QuotaExceededException;
@@ -28,6 +29,8 @@ import com.callv2.drive.domain.validation.handler.Notification;
 
 public class DefaultCreateFileUseCase extends CreateFileUseCase {
 
+    private final EventDispatcher eventDispatcher;
+
     private final MemberGateway memberGateway;
     private final FolderGateway folderGateway;
     private final FileGateway fileGateway;
@@ -36,12 +39,14 @@ public class DefaultCreateFileUseCase extends CreateFileUseCase {
     private final AclGateway aclGateway;
 
     public DefaultCreateFileUseCase(
+            final EventDispatcher eventDispatcher,
             final MemberGateway memberGateway,
             final FolderGateway folderGateway,
             final FileGateway fileGateway,
             final StorageKeyGenerator storageKeyGenerator,
             final StorageGateway storageGateway,
             final AclGateway aclGateway) {
+        this.eventDispatcher = Objects.requireNonNull(eventDispatcher);
         this.memberGateway = Objects.requireNonNull(memberGateway);
         this.folderGateway = Objects.requireNonNull(folderGateway);
         this.fileGateway = Objects.requireNonNull(fileGateway);
@@ -54,13 +59,13 @@ public class DefaultCreateFileUseCase extends CreateFileUseCase {
     public CreateFileOutput execute(final CreateFileInput input) {
 
         final MemberID creatorId = memberGateway
-                .findById(MemberID.of(input.ownerId()))
+                .findById(MemberID.of(input.creatorId()))
                 .map(Member::getId)
-                .orElseThrow(() -> NotFoundException.with(Member.class, input.ownerId().toString()));
+                .orElseThrow(() -> NotFoundException.with(Member.class, input.creatorId().toString()));
 
         final FolderID folderId = FolderID.of(input.folderId());
         final Folder folder = folderGateway
-                .findById(folderId)
+                .findByIdWithMemberAccess(folderId, creatorId)
                 .orElseThrow(() -> NotFoundException.with(Folder.class, input.folderId().toString()));
 
         final Acl folderAcl = this.aclGateway
@@ -97,9 +102,10 @@ public class DefaultCreateFileUseCase extends CreateFileUseCase {
 
         final Acl fileInheritedAcl = folderAcl.createInherited(Resource.file(file.getId()));
 
-        aclGateway.create(fileInheritedAcl);
-
+        eventDispatcher.notify(aclGateway.create(fileInheritedAcl));
         storeFile(file);
+
+        eventDispatcher.notify(file);
 
         return CreateFileOutput.from(file);
     }

--- a/application/src/main/java/com/callv2/drive/application/file/create/DefaultCreateFileUseCase.java
+++ b/application/src/main/java/com/callv2/drive/application/file/create/DefaultCreateFileUseCase.java
@@ -1,14 +1,15 @@
 package com.callv2.drive.application.file.create;
 
-import java.io.InputStream;
 import java.util.List;
 import java.util.Objects;
-import java.util.UUID;
 
+import com.callv2.drive.domain.access.AccessPermission;
+import com.callv2.drive.domain.access.Acl;
+import com.callv2.drive.domain.access.AclGateway;
+import com.callv2.drive.domain.access.Resource;
 import com.callv2.drive.domain.exception.InternalErrorException;
 import com.callv2.drive.domain.exception.NotFoundException;
 import com.callv2.drive.domain.exception.QuotaExceededException;
-import com.callv2.drive.domain.exception.StorageKeyAlreadyExistsException;
 import com.callv2.drive.domain.exception.ValidationException;
 import com.callv2.drive.domain.file.Content;
 import com.callv2.drive.domain.file.File;
@@ -20,7 +21,8 @@ import com.callv2.drive.domain.folder.FolderID;
 import com.callv2.drive.domain.member.Member;
 import com.callv2.drive.domain.member.MemberGateway;
 import com.callv2.drive.domain.member.MemberID;
-import com.callv2.drive.domain.storage.StorageService;
+import com.callv2.drive.domain.storage.StorageGateway;
+import com.callv2.drive.domain.storage.StorageKeyGenerator;
 import com.callv2.drive.domain.validation.ValidationError;
 import com.callv2.drive.domain.validation.handler.Notification;
 
@@ -29,42 +31,49 @@ public class DefaultCreateFileUseCase extends CreateFileUseCase {
     private final MemberGateway memberGateway;
     private final FolderGateway folderGateway;
     private final FileGateway fileGateway;
-    private final StorageService storageService;
+    private final StorageKeyGenerator storageKeyGenerator;
+    private final StorageGateway storageGateway;
+    private final AclGateway aclGateway;
 
     public DefaultCreateFileUseCase(
             final MemberGateway memberGateway,
             final FolderGateway folderGateway,
             final FileGateway fileGateway,
-            final StorageService storageService) {
+            final StorageKeyGenerator storageKeyGenerator,
+            final StorageGateway storageGateway,
+            final AclGateway aclGateway) {
         this.memberGateway = Objects.requireNonNull(memberGateway);
         this.folderGateway = Objects.requireNonNull(folderGateway);
         this.fileGateway = Objects.requireNonNull(fileGateway);
-        this.storageService = Objects.requireNonNull(storageService);
+        this.storageKeyGenerator = Objects.requireNonNull(storageKeyGenerator);
+        this.storageGateway = Objects.requireNonNull(storageGateway);
+        this.aclGateway = Objects.requireNonNull(aclGateway);
     }
 
     @Override
     public CreateFileOutput execute(final CreateFileInput input) {
 
-        final MemberID ownerId = MemberID.of(input.ownerId());
-
-        final Member owner = memberGateway
-                .findById(ownerId)
+        final MemberID creatorId = memberGateway
+                .findById(MemberID.of(input.ownerId()))
+                .map(Member::getId)
                 .orElseThrow(() -> NotFoundException.with(Member.class, input.ownerId().toString()));
 
-        final Long actualUsedQuota = fileGateway
-                .findByOwner(ownerId)
-                .stream()
-                .map(File::getContent)
-                .mapToLong(Content::size)
-                .sum();
-
-        if (actualUsedQuota + input.size() > owner.getQuota().sizeInBytes())
-            throw QuotaExceededException.with(owner.getQuota());
-
-        final FolderID folderId = folderGateway
-                .findById(FolderID.of(input.folderId()))
-                .map(Folder::getId)
+        final FolderID folderId = FolderID.of(input.folderId());
+        final Folder folder = folderGateway
+                .findById(folderId)
                 .orElseThrow(() -> NotFoundException.with(Folder.class, input.folderId().toString()));
+
+        final Acl folderAcl = this.aclGateway
+                .findByResource(Resource.folder(folderId))
+                .orElseThrow();// TODO throw some exception
+
+        checkAccessPermission(creatorId, folderAcl);
+
+        final Member owner = memberGateway
+                .findById(folder.getOwner())
+                .orElseThrow(() -> NotFoundException.with(Member.class, folder.getOwner().toString()));
+
+        checkQuota(owner, input.size());
 
         final Notification notification = Notification.create();
 
@@ -78,19 +87,46 @@ public class DefaultCreateFileUseCase extends CreateFileUseCase {
             throw ValidationException.with("Could not create Aggregate File",
                     ValidationError.with("File with same name already exists on this folder"));
 
-        final String storageKey = storeContentFile(input.content());
-        final String contentType = input.contentType();
-        final Long contentSize = input.size();
+        final Content content = storeContentFile(input);
 
-        final Content content = Content.of(storageKey, contentType, contentSize);
+        final File file = notification
+                .validate(() -> File.create(creatorId, folder.getOwner(), folderId, fileName, content));
 
-        final File file = notification.validate(() -> File.create(ownerId, folderId, fileName, content));
         if (notification.hasError())
             throw ValidationException.with("Could not create Aggregate File", notification);
+
+        final Acl fileInheritedAcl = folderAcl.createInherited(Resource.file(file.getId()));
+
+        aclGateway.create(fileInheritedAcl);
 
         storeFile(file);
 
         return CreateFileOutput.from(file);
+    }
+
+    private void checkAccessPermission(final MemberID memberId, final Acl folderAcl) {
+
+        final AccessPermission folderAclPermission = folderAcl
+                .effectiveAccessPermission(memberId)
+                .orElseThrow();// TODO throw some exception
+
+        if (!folderAclPermission.canWrite())
+            throw new RuntimeException("You don't have permission to create files in this folder");// TODO domain
+
+    }
+
+    private void checkQuota(final Member owner, final Long newFileSize) {
+
+        final Long actualUsedQuota = fileGateway
+                .findByOwner(owner.getId())
+                .stream()
+                .map(File::getContent)
+                .mapToLong(Content::size)
+                .sum();
+
+        if (actualUsedQuota + newFileSize > owner.getQuota().sizeInBytes())
+            throw QuotaExceededException.with(owner.getQuota());
+
     }
 
     private void storeFile(final File file) {
@@ -102,21 +138,17 @@ public class DefaultCreateFileUseCase extends CreateFileUseCase {
         }
     }
 
-    private String storeContentFile(final InputStream inputStream) {
+    private Content storeContentFile(final CreateFileInput input) {
 
         try {
 
-            do {
+            final String storageKey = storageKeyGenerator.generate();
+            final String contentType = input.contentType();
+            final Long contentSize = input.size();
 
-                try {
-                    final String key = UUID.randomUUID().toString();
-                    storageService.store(key, inputStream);
-                    return key;
-                } catch (StorageKeyAlreadyExistsException e) {
-                    continue;
-                }
+            storageGateway.store(storageKey, input.content());
 
-            } while (true);
+            return Content.of(storageKey, contentType, contentSize);
 
         } catch (Exception e) {
             throw InternalErrorException.with("Could not store BinaryContent", e);
@@ -126,7 +158,7 @@ public class DefaultCreateFileUseCase extends CreateFileUseCase {
 
     private void deleteContentFile(final String contentLocation) {
         try {
-            storageService.delete(contentLocation);
+            storageGateway.delete(contentLocation);
         } catch (Exception e) {
             throw InternalErrorException.with("Could not delete BinaryContent", e);
         }

--- a/application/src/main/java/com/callv2/drive/application/file/delete/DefaultDeleteFileUseCase.java
+++ b/application/src/main/java/com/callv2/drive/application/file/delete/DefaultDeleteFileUseCase.java
@@ -32,11 +32,11 @@ public class DefaultDeleteFileUseCase extends DeleteFileUseCase {
         final MemberID deleterId = MemberID.of(input.deleterId());
         final FileID fileId = FileID.of(input.fileId());
 
-        final Member member = memberGateway
+        final Member deleter = memberGateway
                 .findById(deleterId)
                 .orElseThrow(() -> NotFoundException.with(Member.class, input.deleterId().toString()));
 
-        if (!member.hasSystemAccess())
+        if (!deleter.hasSystemAccess())
             throw NotAllowedException.with("Member does not have permission to delete files.");
 
         final File file = fileGateway

--- a/application/src/main/java/com/callv2/drive/application/file/delete/DefaultDeleteFileUseCase.java
+++ b/application/src/main/java/com/callv2/drive/application/file/delete/DefaultDeleteFileUseCase.java
@@ -33,7 +33,7 @@ public class DefaultDeleteFileUseCase extends DeleteFileUseCase {
         final FileID fileId = FileID.of(input.fileId());
 
         final Member member = memberGateway.findById(ownerId)
-                .orElseThrow(() -> NotFoundException.with(Member.class, input.deleterId()));
+                .orElseThrow(() -> NotFoundException.with(Member.class, input.deleterId().toString()));
 
         if (!member.hasSystemAccess())
             throw NotAllowedException.with("Member does not have permission to delete files.");

--- a/application/src/main/java/com/callv2/drive/application/file/delete/DefaultDeleteFileUseCase.java
+++ b/application/src/main/java/com/callv2/drive/application/file/delete/DefaultDeleteFileUseCase.java
@@ -29,19 +29,21 @@ public class DefaultDeleteFileUseCase extends DeleteFileUseCase {
 
     @Override
     public void execute(final DeleteFileInput input) {
-        final MemberID ownerId = MemberID.of(input.deleterId());
+        final MemberID deleterId = MemberID.of(input.deleterId());
         final FileID fileId = FileID.of(input.fileId());
 
-        final Member member = memberGateway.findById(ownerId)
+        final Member member = memberGateway
+                .findById(deleterId)
                 .orElseThrow(() -> NotFoundException.with(Member.class, input.deleterId().toString()));
 
         if (!member.hasSystemAccess())
             throw NotAllowedException.with("Member does not have permission to delete files.");
 
-        final File file = fileGateway.findById(fileId)
+        final File file = fileGateway
+                .findByIdWithMemberAccess(fileId, deleterId)
                 .orElseThrow(() -> NotFoundException.with(File.class, input.fileId().toString()));
 
-        eventDispatcher.notify(fileGateway.update(file.delete()));
+        eventDispatcher.notify(fileGateway.update(file.delete(deleterId)));
 
     }
 

--- a/application/src/main/java/com/callv2/drive/application/file/delete/DeleteFileInput.java
+++ b/application/src/main/java/com/callv2/drive/application/file/delete/DeleteFileInput.java
@@ -2,9 +2,9 @@ package com.callv2.drive.application.file.delete;
 
 import java.util.UUID;
 
-public record DeleteFileInput(String deleterId, UUID fileId) {
+public record DeleteFileInput(UUID deleterId, UUID fileId) {
 
-    public static DeleteFileInput of(final String deleterId, final UUID fileId) {
+    public static DeleteFileInput of(final UUID deleterId, final UUID fileId) {
         return new DeleteFileInput(deleterId, fileId);
     }
 

--- a/application/src/main/java/com/callv2/drive/application/file/retrieve/get/DefaultGetFileUseCase.java
+++ b/application/src/main/java/com/callv2/drive/application/file/retrieve/get/DefaultGetFileUseCase.java
@@ -6,6 +6,7 @@ import com.callv2.drive.domain.exception.NotFoundException;
 import com.callv2.drive.domain.file.File;
 import com.callv2.drive.domain.file.FileGateway;
 import com.callv2.drive.domain.file.FileID;
+import com.callv2.drive.domain.member.MemberID;
 
 public class DefaultGetFileUseCase extends GetFileUseCase {
 
@@ -18,9 +19,9 @@ public class DefaultGetFileUseCase extends GetFileUseCase {
     @Override
     public GetFileOutput execute(GetFileInput input) {
         return fileGateway
-                .findById(FileID.of(input.id()))
+                .findByIdWithMemberAccess(FileID.of(input.fileId()), MemberID.of(input.actorId()))
                 .map(GetFileOutput::from)
-                .orElseThrow(() -> NotFoundException.with(File.class, input.id().toString()));
+                .orElseThrow(() -> NotFoundException.with(File.class, input.fileId().toString()));
     }
 
 }

--- a/application/src/main/java/com/callv2/drive/application/file/retrieve/get/GetFileInput.java
+++ b/application/src/main/java/com/callv2/drive/application/file/retrieve/get/GetFileInput.java
@@ -2,10 +2,10 @@ package com.callv2.drive.application.file.retrieve.get;
 
 import java.util.UUID;
 
-public record GetFileInput(UUID id) {
+public record GetFileInput(UUID fileId, UUID actorId) {
 
-    public static GetFileInput from(UUID id) {
-        return new GetFileInput(id);
+    public static GetFileInput from(final UUID id, final UUID actorId) {
+        return new GetFileInput(id, actorId);
     }
 
 }

--- a/application/src/main/java/com/callv2/drive/application/file/retrieve/get/GetFileOutput.java
+++ b/application/src/main/java/com/callv2/drive/application/file/retrieve/get/GetFileOutput.java
@@ -12,19 +12,27 @@ public record GetFileOutput(
         String name,
         String contentType,
         Long contentSize,
+        UUID creatorId,
         Instant createdAt,
-        Instant updatedAt) {
+        UUID updaterId,
+        Instant updatedAt,
+        UUID deleterId,
+        Instant deletedAt) {
 
-    public static GetFileOutput from(final File aFile) {
+    public static GetFileOutput from(final File file) {
         return new GetFileOutput(
-                aFile.getId().getValue(),
-                aFile.getOwner().getValue(),
-                aFile.getFolder().getValue(),
-                aFile.getName().value(),
-                aFile.getContent().type(),
-                aFile.getContent().size(),
-                aFile.getCreatedAt(),
-                aFile.getUpdatedAt());
+                file.getId().getValue(),
+                file.getOwner().getValue(),
+                file.getFolder().getValue(),
+                file.getName().value(),
+                file.getContent().type(),
+                file.getContent().size(),
+                file.getCreator().getValue(),
+                file.getCreatedAt(),
+                file.getUpdatedBy().getValue(),
+                file.getUpdatedAt(),
+                file.getDeletedBy() != null ? file.getDeletedBy().getValue() : null,
+                file.getDeletedAt());
     }
 
 }

--- a/application/src/main/java/com/callv2/drive/application/file/retrieve/get/GetFileOutput.java
+++ b/application/src/main/java/com/callv2/drive/application/file/retrieve/get/GetFileOutput.java
@@ -7,7 +7,7 @@ import com.callv2.drive.domain.file.File;
 
 public record GetFileOutput(
         UUID id,
-        String ownerId,
+        UUID ownerId,
         UUID folderId,
         String name,
         String contentType,

--- a/application/src/main/java/com/callv2/drive/application/file/retrieve/list/DefaultListFilesUseCase.java
+++ b/application/src/main/java/com/callv2/drive/application/file/retrieve/list/DefaultListFilesUseCase.java
@@ -3,8 +3,8 @@ package com.callv2.drive.application.file.retrieve.list;
 import java.util.Objects;
 
 import com.callv2.drive.domain.file.FileGateway;
+import com.callv2.drive.domain.member.MemberID;
 import com.callv2.drive.domain.pagination.Page;
-import com.callv2.drive.domain.pagination.SearchQuery;
 
 public class DefaultListFilesUseCase extends ListFilesUseCase {
 
@@ -15,9 +15,9 @@ public class DefaultListFilesUseCase extends ListFilesUseCase {
     }
 
     @Override
-    public Page<FileListOutput> execute(final SearchQuery query) {
+    public Page<FileListOutput> execute(final FileListInput input) {
         return this.fileGateway
-                .findAll(query)
+                .findAllWithMemberAccess(input.query(), MemberID.of(input.actorId()))
                 .map(FileListOutput::from);
     }
 

--- a/application/src/main/java/com/callv2/drive/application/file/retrieve/list/FileListInput.java
+++ b/application/src/main/java/com/callv2/drive/application/file/retrieve/list/FileListInput.java
@@ -1,0 +1,11 @@
+package com.callv2.drive.application.file.retrieve.list;
+
+import java.util.UUID;
+
+import com.callv2.drive.domain.pagination.SearchQuery;
+
+public record FileListInput(
+        UUID actorId,
+        SearchQuery query) {
+
+}

--- a/application/src/main/java/com/callv2/drive/application/file/retrieve/list/FileListOutput.java
+++ b/application/src/main/java/com/callv2/drive/application/file/retrieve/list/FileListOutput.java
@@ -7,7 +7,7 @@ import com.callv2.drive.domain.file.File;
 
 public record FileListOutput(
         UUID id,
-        String ownerId,
+        UUID ownerId,
         UUID folderId,
         String name,
         String contentType,

--- a/application/src/main/java/com/callv2/drive/application/file/retrieve/list/ListFilesUseCase.java
+++ b/application/src/main/java/com/callv2/drive/application/file/retrieve/list/ListFilesUseCase.java
@@ -2,8 +2,7 @@ package com.callv2.drive.application.file.retrieve.list;
 
 import com.callv2.drive.application.UseCase;
 import com.callv2.drive.domain.pagination.Page;
-import com.callv2.drive.domain.pagination.SearchQuery;
 
-public abstract class ListFilesUseCase extends UseCase<SearchQuery, Page<FileListOutput>> {
+public abstract class ListFilesUseCase extends UseCase<FileListInput, Page<FileListOutput>> {
 
 }

--- a/application/src/main/java/com/callv2/drive/application/folder/create/CreateFolderInput.java
+++ b/application/src/main/java/com/callv2/drive/application/folder/create/CreateFolderInput.java
@@ -2,9 +2,9 @@ package com.callv2.drive.application.folder.create;
 
 import java.util.UUID;
 
-public record CreateFolderInput(String ownerId, String name, UUID parentFolderId) {
+public record CreateFolderInput(UUID creatorId, String name, UUID parentFolderId) {
 
-    public static CreateFolderInput from(String ownerdId, String name, UUID parentFolderId) {
+    public static CreateFolderInput from(UUID ownerdId, String name, UUID parentFolderId) {
         return new CreateFolderInput(ownerdId, name, parentFolderId);
     }
 

--- a/application/src/main/java/com/callv2/drive/application/folder/create/CreateFolderInput.java
+++ b/application/src/main/java/com/callv2/drive/application/folder/create/CreateFolderInput.java
@@ -4,8 +4,8 @@ import java.util.UUID;
 
 public record CreateFolderInput(UUID creatorId, String name, UUID parentFolderId) {
 
-    public static CreateFolderInput from(UUID ownerdId, String name, UUID parentFolderId) {
-        return new CreateFolderInput(ownerdId, name, parentFolderId);
+    public static CreateFolderInput from(UUID creatorId, String name, UUID parentFolderId) {
+        return new CreateFolderInput(creatorId, name, parentFolderId);
     }
 
 }

--- a/application/src/main/java/com/callv2/drive/application/folder/create/DefaultCreateFolderUseCase.java
+++ b/application/src/main/java/com/callv2/drive/application/folder/create/DefaultCreateFolderUseCase.java
@@ -2,6 +2,12 @@ package com.callv2.drive.application.folder.create;
 
 import java.util.Set;
 
+import com.callv2.drive.domain.access.AccessPermission;
+import com.callv2.drive.domain.access.Acl;
+import com.callv2.drive.domain.access.AclGateway;
+import com.callv2.drive.domain.access.Resource;
+import com.callv2.drive.domain.event.EventDispatcher;
+import com.callv2.drive.domain.exception.NotAllowedException;
 import com.callv2.drive.domain.exception.NotFoundException;
 import com.callv2.drive.domain.exception.ValidationException;
 import com.callv2.drive.domain.folder.Folder;
@@ -16,10 +22,19 @@ import com.callv2.drive.domain.validation.handler.Notification;
 
 public class DefaultCreateFolderUseCase extends CreateFolderUseCase {
 
+    private final EventDispatcher eventDispatcher;
+
+    private final AclGateway aclGateway;
     private final MemberGateway memberGateway;
     private final FolderGateway folderGateway;
 
-    public DefaultCreateFolderUseCase(final MemberGateway memberGateway, final FolderGateway folderGateway) {
+    public DefaultCreateFolderUseCase(
+            final EventDispatcher eventDispatcher,
+            final AclGateway aclGateway,
+            final MemberGateway memberGateway,
+            final FolderGateway folderGateway) {
+        this.eventDispatcher = eventDispatcher;
+        this.aclGateway = aclGateway;
         this.memberGateway = memberGateway;
         this.folderGateway = folderGateway;
     }
@@ -40,7 +55,7 @@ public class DefaultCreateFolderUseCase extends CreateFolderUseCase {
         return CreateFolderOutput.from(createFolder(creatorId, FolderName.of(input.name()), parentFolder));
     }
 
-    private Folder createFolder(final MemberID creatorId, FolderName name, final Folder parentFolder) {
+    private Folder createFolder(final MemberID creatorId, final FolderName name, final Folder parentFolder) {
 
         final Notification notification = Notification.create();
 
@@ -55,8 +70,27 @@ public class DefaultCreateFolderUseCase extends CreateFolderUseCase {
         if (notification.hasError())
             throw ValidationException.with("Could not create Aggregate Folder", notification);
 
-        folderGateway.update(parentFolder);
+        final Acl parentFolderAcl = this.aclGateway
+                .findByResource(Resource.folder(parentFolder.getId()))
+                .orElseThrow(() -> NotAllowedException.with("You don't have any permissions in this folder"));
+
+        checkWriteAccessPermission(creatorId, parentFolderAcl);
+
+        final Acl newFolderAcl = parentFolderAcl.createInherited(Resource.folder(folder.getId()));
+        eventDispatcher.notify(aclGateway.create(newFolderAcl));
+
         return folderGateway.create(folder);
+    }
+
+    private void checkWriteAccessPermission(final MemberID memberId, final Acl folderAcl) {
+
+        final AccessPermission folderAclPermission = folderAcl
+                .effectiveAccessPermission(memberId)
+                .orElseThrow(() -> NotAllowedException.with("You don't have any permissions in this folder"));
+
+        if (!folderAclPermission.canWrite())
+            throw NotAllowedException.with("You don't have permission to create files in this folder");
+
     }
 
 }

--- a/application/src/main/java/com/callv2/drive/application/folder/create/DefaultCreateFolderUseCase.java
+++ b/application/src/main/java/com/callv2/drive/application/folder/create/DefaultCreateFolderUseCase.java
@@ -59,7 +59,9 @@ public class DefaultCreateFolderUseCase extends CreateFolderUseCase {
 
         final Notification notification = Notification.create();
 
-        final Set<Folder> subFolders = folderGateway.findByParentFolderId(parentFolder.getId());
+        final Set<Folder> subFolders = folderGateway.findByParentFolderIdWithMemberAccess(
+                parentFolder.getId(),
+                creatorId);
 
         if (subFolders.stream().anyMatch(subFolder -> subFolder.getName().equals(name)))
             notification.append(ValidationError.with("Folder with the same name already exists"));

--- a/application/src/main/java/com/callv2/drive/application/folder/create/DefaultCreateFolderUseCase.java
+++ b/application/src/main/java/com/callv2/drive/application/folder/create/DefaultCreateFolderUseCase.java
@@ -26,10 +26,10 @@ public class DefaultCreateFolderUseCase extends CreateFolderUseCase {
 
     @Override
     public CreateFolderOutput execute(final CreateFolderInput input) {
-        final MemberID ownerId = MemberID.of(input.ownerId());
+        final MemberID ownerId = MemberID.of(input.creatorId());
 
         if (!memberGateway.existsById(ownerId))
-            throw NotFoundException.with(Member.class, input.ownerId().toString());
+            throw NotFoundException.with(Member.class, input.creatorId().toString());
 
         final Folder parentFolder = folderGateway
                 .findById(FolderID.of(input.parentFolderId()))

--- a/application/src/main/java/com/callv2/drive/application/folder/create/DefaultCreateFolderUseCase.java
+++ b/application/src/main/java/com/callv2/drive/application/folder/create/DefaultCreateFolderUseCase.java
@@ -26,21 +26,21 @@ public class DefaultCreateFolderUseCase extends CreateFolderUseCase {
 
     @Override
     public CreateFolderOutput execute(final CreateFolderInput input) {
-        final MemberID ownerId = MemberID.of(input.creatorId());
+        final MemberID creatorId = MemberID.of(input.creatorId());
 
-        if (!memberGateway.existsById(ownerId))
+        if (!memberGateway.existsById(creatorId))
             throw NotFoundException.with(Member.class, input.creatorId().toString());
 
         final Folder parentFolder = folderGateway
-                .findById(FolderID.of(input.parentFolderId()))
+                .findByIdWithMemberAccess(FolderID.of(input.parentFolderId()), creatorId)
                 .orElseThrow(() -> NotFoundException.with(
                         Folder.class,
                         "Parent folder with id %s not found".formatted(input.parentFolderId().toString())));
 
-        return CreateFolderOutput.from(createFolder(ownerId, FolderName.of(input.name()), parentFolder));
+        return CreateFolderOutput.from(createFolder(creatorId, FolderName.of(input.name()), parentFolder));
     }
 
-    private Folder createFolder(final MemberID ownerId, FolderName name, final Folder parentFolder) {
+    private Folder createFolder(final MemberID creatorId, FolderName name, final Folder parentFolder) {
 
         final Notification notification = Notification.create();
 
@@ -49,7 +49,8 @@ public class DefaultCreateFolderUseCase extends CreateFolderUseCase {
         if (subFolders.stream().anyMatch(subFolder -> subFolder.getName().equals(name)))
             notification.append(ValidationError.with("Folder with the same name already exists"));
 
-        final Folder folder = notification.validate(() -> Folder.create(ownerId, name, parentFolder));
+        final Folder folder = notification
+                .validate(() -> Folder.create(creatorId, parentFolder.getOwner(), name, parentFolder));
 
         if (notification.hasError())
             throw ValidationException.with("Could not create Aggregate Folder", notification);

--- a/application/src/main/java/com/callv2/drive/application/folder/delete/DefaultDeleteFolderUseCase.java
+++ b/application/src/main/java/com/callv2/drive/application/folder/delete/DefaultDeleteFolderUseCase.java
@@ -38,7 +38,7 @@ public class DefaultDeleteFolderUseCase extends DeleteFolderUseCase {
                 .findByIdWithMemberAccess(folderId, actorId)
                 .orElseThrow(() -> NotFoundException.with(Folder.class, folderId.getValue().toString()));
 
-        final List<File> deletedFiles = deleteRecursively(folder.getId());
+        final List<File> deletedFiles = deleteRecursively(folder.getId(), actorId);
 
         for (File deletedFile : deletedFiles) {
             eventDispatcher.notify(deletedFile);
@@ -46,13 +46,13 @@ public class DefaultDeleteFolderUseCase extends DeleteFolderUseCase {
 
     }
 
-    private List<File> deleteRecursively(final FolderID folderId) {
+    private List<File> deleteRecursively(final FolderID folderId, final MemberID actorId) {
 
         final List<File> storageKeysToBeDeleted = new ArrayList<>(deleteFiles(folderId));
-        final Set<Folder> childrenFolders = folderGateway.findByParentFolderId(folderId);
+        final Set<Folder> childrenFolders = folderGateway.findByParentFolderIdWithMemberAccess(folderId, actorId);
 
         for (Folder children : childrenFolders) {
-            storageKeysToBeDeleted.addAll(deleteRecursively(children.getId()));
+            storageKeysToBeDeleted.addAll(deleteRecursively(children.getId(), actorId));
         }
 
         this.folderGateway.deleteById(folderId);

--- a/application/src/main/java/com/callv2/drive/application/folder/delete/DefaultDeleteFolderUseCase.java
+++ b/application/src/main/java/com/callv2/drive/application/folder/delete/DefaultDeleteFolderUseCase.java
@@ -63,7 +63,7 @@ public class DefaultDeleteFolderUseCase extends DeleteFolderUseCase {
 
     private List<File> deleteFiles(final FolderID folderId, MemberID deleterId) {
 
-        final List<File> fileList = fileGateway.findByFolder(folderId);
+        final List<File> fileList = fileGateway.findAllActiveByFolder(folderId);
 
         for (File file : fileList) {
             fileGateway.update(file.delete(deleterId));

--- a/application/src/main/java/com/callv2/drive/application/folder/delete/DefaultDeleteFolderUseCase.java
+++ b/application/src/main/java/com/callv2/drive/application/folder/delete/DefaultDeleteFolderUseCase.java
@@ -48,7 +48,7 @@ public class DefaultDeleteFolderUseCase extends DeleteFolderUseCase {
 
     private List<File> deleteRecursively(final FolderID folderId, final MemberID actorId) {
 
-        final List<File> storageKeysToBeDeleted = new ArrayList<>(deleteFiles(folderId));
+        final List<File> storageKeysToBeDeleted = new ArrayList<>(deleteFiles(folderId, actorId));
         final Set<Folder> childrenFolders = folderGateway.findByParentFolderIdWithMemberAccess(folderId, actorId);
 
         for (Folder children : childrenFolders) {
@@ -61,12 +61,12 @@ public class DefaultDeleteFolderUseCase extends DeleteFolderUseCase {
 
     }
 
-    private List<File> deleteFiles(final FolderID folderId) {
+    private List<File> deleteFiles(final FolderID folderId, MemberID deleterId) {
 
         final List<File> fileList = fileGateway.findByFolder(folderId);
 
         for (File file : fileList) {
-            fileGateway.update(file.delete());
+            fileGateway.update(file.delete(deleterId));
         }
 
         return fileList;

--- a/application/src/main/java/com/callv2/drive/application/folder/delete/DefaultDeleteFolderUseCase.java
+++ b/application/src/main/java/com/callv2/drive/application/folder/delete/DefaultDeleteFolderUseCase.java
@@ -11,6 +11,7 @@ import com.callv2.drive.domain.file.FileGateway;
 import com.callv2.drive.domain.folder.Folder;
 import com.callv2.drive.domain.folder.FolderGateway;
 import com.callv2.drive.domain.folder.FolderID;
+import com.callv2.drive.domain.member.MemberID;
 
 public class DefaultDeleteFolderUseCase extends DeleteFolderUseCase {
 
@@ -31,9 +32,10 @@ public class DefaultDeleteFolderUseCase extends DeleteFolderUseCase {
     public void execute(final DeleteFolderInput input) {
 
         final FolderID folderId = FolderID.of(input.id());
+        final MemberID actorId = MemberID.of(input.actorId());
 
         final Folder folder = folderGateway
-                .findById(FolderID.of(input.id()))
+                .findByIdWithMemberAccess(folderId, actorId)
                 .orElseThrow(() -> NotFoundException.with(Folder.class, folderId.getValue().toString()));
 
         final List<File> deletedFiles = deleteRecursively(folder.getId());

--- a/application/src/main/java/com/callv2/drive/application/folder/delete/DeleteFolderInput.java
+++ b/application/src/main/java/com/callv2/drive/application/folder/delete/DeleteFolderInput.java
@@ -2,6 +2,6 @@ package com.callv2.drive.application.folder.delete;
 
 import java.util.UUID;
 
-public record DeleteFolderInput(UUID id, UUID memberId) {
+public record DeleteFolderInput(UUID id, UUID actorId) {
 
 }

--- a/application/src/main/java/com/callv2/drive/application/folder/delete/DeleteFolderInput.java
+++ b/application/src/main/java/com/callv2/drive/application/folder/delete/DeleteFolderInput.java
@@ -2,6 +2,6 @@ package com.callv2.drive.application.folder.delete;
 
 import java.util.UUID;
 
-public record DeleteFolderInput(UUID id, String memberId) {
+public record DeleteFolderInput(UUID id, UUID memberId) {
 
 }

--- a/application/src/main/java/com/callv2/drive/application/folder/move/DefaultMoveFolderUseCase.java
+++ b/application/src/main/java/com/callv2/drive/application/folder/move/DefaultMoveFolderUseCase.java
@@ -3,6 +3,11 @@ package com.callv2.drive.application.folder.move;
 import java.util.Objects;
 import java.util.Set;
 
+import com.callv2.drive.domain.access.AccessPermission;
+import com.callv2.drive.domain.access.Acl;
+import com.callv2.drive.domain.access.AclGateway;
+import com.callv2.drive.domain.access.Resource;
+import com.callv2.drive.domain.exception.NotAllowedException;
 import com.callv2.drive.domain.exception.NotFoundException;
 import com.callv2.drive.domain.exception.ValidationException;
 import com.callv2.drive.domain.folder.Folder;
@@ -14,9 +19,11 @@ import com.callv2.drive.domain.validation.handler.Notification;
 
 public class DefaultMoveFolderUseCase extends MoveFolderUseCase {
 
+    private final AclGateway aclGateway;
     private final FolderGateway folderGateway;
 
-    public DefaultMoveFolderUseCase(final FolderGateway folderGateway) {
+    public DefaultMoveFolderUseCase(final AclGateway aclGateway, final FolderGateway folderGateway) {
+        this.aclGateway = Objects.requireNonNull(aclGateway);
         this.folderGateway = Objects.requireNonNull(folderGateway);
     }
 
@@ -30,12 +37,24 @@ public class DefaultMoveFolderUseCase extends MoveFolderUseCase {
         final Folder folder = findFolder(folderId, actorId);
         final Folder newParentFolder = findFolder(newParentFolderId, actorId);
 
+        final Acl folderAcl = aclGateway
+                .findByResource(Resource.folder(folderId))
+                .orElseThrow(() -> NotFoundException.with(Folder.class, folderId.getValue().toString()));
+        checkFolderAccessPermission(folderAcl, folderId, actorId);
+
+        final Acl parentFolderAcl = aclGateway
+                .findByResource(Resource.folder(newParentFolderId))
+                .orElseThrow(() -> NotFoundException.with(Folder.class, newParentFolderId.getValue().toString()));
+        checkParentFolderAccessPermission(parentFolderAcl, newParentFolderId, actorId);
+
         final Notification notification = Notification.create();
         validateMove(folder, newParentFolder, actorId, notification);
         if (notification.hasError())
             throw ValidationException.with("Invalid move operation", notification);
 
         folder.changeParentFolder(newParentFolder);
+
+        aclGateway.update(folderAcl.inheritFrom(parentFolderAcl));
 
         folderGateway.update(folder);
     }
@@ -78,6 +97,34 @@ public class DefaultMoveFolderUseCase extends MoveFolderUseCase {
 
             actualParent = findFolder(actualParent.getParentFolder(), actorId);
         }
+
+    }
+
+    private void checkFolderAccessPermission(
+            final Acl parentFolderAcl,
+            final FolderID newParentFolderId,
+            final MemberID actorId) {
+
+        final AccessPermission folderEffectiveAccessPermission = parentFolderAcl
+                .effectiveAccessPermission(actorId)
+                .orElseThrow(() -> NotFoundException.with(Folder.class, newParentFolderId.getValue().toString()));
+
+        if (!folderEffectiveAccessPermission.canWrite())
+            throw NotAllowedException.with("You do not have permission to move this folder.");
+
+    }
+
+    private void checkParentFolderAccessPermission(
+            final Acl parentFolderAcl,
+            final FolderID newParentFolderId,
+            final MemberID actorId) {
+
+        final AccessPermission folderEffectiveAccessPermission = parentFolderAcl
+                .effectiveAccessPermission(actorId)
+                .orElseThrow(() -> NotFoundException.with(Folder.class, newParentFolderId.getValue().toString()));
+
+        if (!folderEffectiveAccessPermission.canWrite())
+            throw NotAllowedException.with("You do not have permission to move folders into the target parent folder.");
 
     }
 

--- a/application/src/main/java/com/callv2/drive/application/folder/move/DefaultMoveFolderUseCase.java
+++ b/application/src/main/java/com/callv2/drive/application/folder/move/DefaultMoveFolderUseCase.java
@@ -8,6 +8,7 @@ import com.callv2.drive.domain.exception.ValidationException;
 import com.callv2.drive.domain.folder.Folder;
 import com.callv2.drive.domain.folder.FolderGateway;
 import com.callv2.drive.domain.folder.FolderID;
+import com.callv2.drive.domain.member.MemberID;
 import com.callv2.drive.domain.validation.ValidationError;
 import com.callv2.drive.domain.validation.handler.Notification;
 
@@ -20,16 +21,17 @@ public class DefaultMoveFolderUseCase extends MoveFolderUseCase {
     }
 
     @Override
-    public void execute(MoveFolderInput input) {
+    public void execute(final MoveFolderInput input) {
 
         final FolderID folderId = FolderID.of(input.id());
         final FolderID newParentFolderId = FolderID.of(input.newParentId());
+        final MemberID actorId = MemberID.of(input.actorId());
 
-        final Folder folder = findFolder(folderId);
-        final Folder newParentFolder = findFolder(newParentFolderId);
+        final Folder folder = findFolder(folderId, actorId);
+        final Folder newParentFolder = findFolder(newParentFolderId, actorId);
 
         final Notification notification = Notification.create();
-        validateMove(folder, newParentFolder, notification);
+        validateMove(folder, newParentFolder, actorId, notification);
         if (notification.hasError())
             throw ValidationException.with("Invalid move operation", notification);
 
@@ -38,13 +40,17 @@ public class DefaultMoveFolderUseCase extends MoveFolderUseCase {
         folderGateway.update(folder);
     }
 
-    private Folder findFolder(FolderID id) {
+    private Folder findFolder(FolderID id, MemberID actorId) {
         return folderGateway
-                .findById(id)
+                .findByIdWithMemberAccess(id, actorId)
                 .orElseThrow(() -> NotFoundException.with(Folder.class, id.getValue().toString()));
     }
 
-    private void validateMove(final Folder folder, final Folder newParentFolder, final Notification notification) {
+    private void validateMove(
+            final Folder folder,
+            final Folder newParentFolder,
+            final MemberID actorId,
+            final Notification notification) {
 
         final Set<Folder> newParentFolderSubFolders = this.folderGateway.findByParentFolderId(newParentFolder.getId());
 
@@ -69,10 +75,9 @@ public class DefaultMoveFolderUseCase extends MoveFolderUseCase {
                 break;
             }
 
-            actualParent = findFolder(actualParent.getParentFolder());
+            actualParent = findFolder(actualParent.getParentFolder(), actorId);
         }
 
-        return;
     }
 
 }

--- a/application/src/main/java/com/callv2/drive/application/folder/move/DefaultMoveFolderUseCase.java
+++ b/application/src/main/java/com/callv2/drive/application/folder/move/DefaultMoveFolderUseCase.java
@@ -52,7 +52,8 @@ public class DefaultMoveFolderUseCase extends MoveFolderUseCase {
             final MemberID actorId,
             final Notification notification) {
 
-        final Set<Folder> newParentFolderSubFolders = this.folderGateway.findByParentFolderId(newParentFolder.getId());
+        final Set<Folder> newParentFolderSubFolders = this.folderGateway
+                .findByParentFolderIdWithMemberAccess(newParentFolder.getId(), actorId);
 
         if (newParentFolderSubFolders.stream().anyMatch(sf -> sf.getName().equals(folder.getName())))
             notification.append(

--- a/application/src/main/java/com/callv2/drive/application/folder/move/MoveFolderInput.java
+++ b/application/src/main/java/com/callv2/drive/application/folder/move/MoveFolderInput.java
@@ -2,10 +2,10 @@ package com.callv2.drive.application.folder.move;
 
 import java.util.UUID;
 
-public record MoveFolderInput(UUID id, UUID newParentId) {
+public record MoveFolderInput(UUID id, UUID newParentId, UUID actorId) {
 
-    public static MoveFolderInput with(UUID id, UUID newParentId) {
-        return new MoveFolderInput(id, newParentId);
+    public static MoveFolderInput with(UUID id, UUID newParentId, UUID actorId) {
+        return new MoveFolderInput(id, newParentId, actorId);
     }
 
 }

--- a/application/src/main/java/com/callv2/drive/application/folder/retrieve/get/DefaultGetFolderUseCase.java
+++ b/application/src/main/java/com/callv2/drive/application/folder/retrieve/get/DefaultGetFolderUseCase.java
@@ -35,7 +35,7 @@ public class DefaultGetFolderUseCase extends GetFolderUseCase {
                 .from(
                         folder,
                         folderGateway.findByParentFolderIdWithMemberAccess(folder.getId(), actorId),
-                        fileGateway.findByFolder(folder.getId()));
+                        fileGateway.findAllActiveByFolder(folder.getId()));
     }
 
 }

--- a/application/src/main/java/com/callv2/drive/application/folder/retrieve/get/DefaultGetFolderUseCase.java
+++ b/application/src/main/java/com/callv2/drive/application/folder/retrieve/get/DefaultGetFolderUseCase.java
@@ -2,10 +2,6 @@ package com.callv2.drive.application.folder.retrieve.get;
 
 import java.util.Objects;
 
-import com.callv2.drive.domain.access.AccessPermission;
-import com.callv2.drive.domain.access.Acl;
-import com.callv2.drive.domain.access.AclGateway;
-import com.callv2.drive.domain.access.Resource;
 import com.callv2.drive.domain.exception.NotFoundException;
 import com.callv2.drive.domain.file.FileGateway;
 import com.callv2.drive.domain.folder.Folder;
@@ -15,15 +11,12 @@ import com.callv2.drive.domain.member.MemberID;
 
 public class DefaultGetFolderUseCase extends GetFolderUseCase {
 
-    private final AclGateway aclGateway;
     private final FolderGateway folderGateway;
     private final FileGateway fileGateway;
 
     public DefaultGetFolderUseCase(
-            final AclGateway aclGateway,
             final FolderGateway folderGateway,
             final FileGateway fileGateway) {
-        this.aclGateway = Objects.requireNonNull(aclGateway);
         this.folderGateway = Objects.requireNonNull(folderGateway);
         this.fileGateway = Objects.requireNonNull(fileGateway);
     }
@@ -33,17 +26,6 @@ public class DefaultGetFolderUseCase extends GetFolderUseCase {
 
         final MemberID actorId = MemberID.of(input.actorId());
         final FolderID folderId = FolderID.of(input.folderId());
-
-        // final Acl folderAcl = aclGateway
-        //         .findByResource(Resource.folder(folderId))
-        //         .orElseThrow();
-
-        // final AccessPermission accessPermission = folderAcl
-        //         .effectiveAccessPermission(actorId)
-        //         .orElseThrow(); // TODO exception for notFound
-
-        // if (!accessPermission.canRead())
-        //     throw new RuntimeException(); // TODO exception for no permission
 
         final Folder folder = folderGateway
                 .findByIdWithMemberAccess(folderId, actorId)

--- a/application/src/main/java/com/callv2/drive/application/folder/retrieve/get/DefaultGetFolderUseCase.java
+++ b/application/src/main/java/com/callv2/drive/application/folder/retrieve/get/DefaultGetFolderUseCase.java
@@ -2,30 +2,52 @@ package com.callv2.drive.application.folder.retrieve.get;
 
 import java.util.Objects;
 
+import com.callv2.drive.domain.access.AccessPermission;
+import com.callv2.drive.domain.access.Acl;
+import com.callv2.drive.domain.access.AclGateway;
+import com.callv2.drive.domain.access.Resource;
 import com.callv2.drive.domain.exception.NotFoundException;
 import com.callv2.drive.domain.file.FileGateway;
 import com.callv2.drive.domain.folder.Folder;
 import com.callv2.drive.domain.folder.FolderGateway;
 import com.callv2.drive.domain.folder.FolderID;
+import com.callv2.drive.domain.member.MemberID;
 
 public class DefaultGetFolderUseCase extends GetFolderUseCase {
 
+    private final AclGateway aclGateway;
     private final FolderGateway folderGateway;
     private final FileGateway fileGateway;
 
     public DefaultGetFolderUseCase(
+            final AclGateway aclGateway,
             final FolderGateway folderGateway,
             final FileGateway fileGateway) {
+        this.aclGateway = Objects.requireNonNull(aclGateway);
         this.folderGateway = Objects.requireNonNull(folderGateway);
         this.fileGateway = Objects.requireNonNull(fileGateway);
     }
 
     @Override
-    public GetFolderOutput execute(GetFolderInput input) {
+    public GetFolderOutput execute(final GetFolderInput input) {
+
+        final MemberID actorId = MemberID.of(input.actorId());
+        final FolderID folderId = FolderID.of(input.folderId());
+
+        // final Acl folderAcl = aclGateway
+        //         .findByResource(Resource.folder(folderId))
+        //         .orElseThrow();
+
+        // final AccessPermission accessPermission = folderAcl
+        //         .effectiveAccessPermission(actorId)
+        //         .orElseThrow(); // TODO exception for notFound
+
+        // if (!accessPermission.canRead())
+        //     throw new RuntimeException(); // TODO exception for no permission
 
         final Folder folder = folderGateway
-                .findById(FolderID.of(input.id()))
-                .orElseThrow(() -> NotFoundException.with(Folder.class, input.id().toString()));
+                .findByIdWithMemberAccess(folderId, actorId)
+                .orElseThrow(() -> NotFoundException.with(Folder.class, input.folderId().toString()));
 
         return GetFolderOutput
                 .from(

--- a/application/src/main/java/com/callv2/drive/application/folder/retrieve/get/DefaultGetFolderUseCase.java
+++ b/application/src/main/java/com/callv2/drive/application/folder/retrieve/get/DefaultGetFolderUseCase.java
@@ -34,7 +34,7 @@ public class DefaultGetFolderUseCase extends GetFolderUseCase {
         return GetFolderOutput
                 .from(
                         folder,
-                        folderGateway.findByParentFolderId(folder.getId()),
+                        folderGateway.findByParentFolderIdWithMemberAccess(folder.getId(), actorId),
                         fileGateway.findByFolder(folder.getId()));
     }
 

--- a/application/src/main/java/com/callv2/drive/application/folder/retrieve/get/GetFolderInput.java
+++ b/application/src/main/java/com/callv2/drive/application/folder/retrieve/get/GetFolderInput.java
@@ -2,10 +2,10 @@ package com.callv2.drive.application.folder.retrieve.get;
 
 import java.util.UUID;
 
-public record GetFolderInput(UUID id) {
+public record GetFolderInput(UUID folderId, UUID actorId) {
 
-    public static GetFolderInput with(final UUID id) {
-        return new GetFolderInput(id);
+    public static GetFolderInput with(final UUID folderId, final UUID actorId) {
+        return new GetFolderInput(folderId, actorId);
     }
 
 }

--- a/application/src/main/java/com/callv2/drive/application/folder/retrieve/get/GetFolderOutput.java
+++ b/application/src/main/java/com/callv2/drive/application/folder/retrieve/get/GetFolderOutput.java
@@ -15,7 +15,7 @@ public record GetFolderOutput(
         UUID parentFolder,
         Set<GetFolderOutput.SubFolder> subFolders,
         Set<GetFolderOutput.File> files,
-        String ownerId,
+        UUID ownerId,
         Instant createdAt,
         Instant updatedAt,
         Instant deletedAt) {

--- a/application/src/main/java/com/callv2/drive/application/folder/retrieve/get/root/DefaultGetRootFolderUseCase.java
+++ b/application/src/main/java/com/callv2/drive/application/folder/retrieve/get/root/DefaultGetRootFolderUseCase.java
@@ -51,7 +51,7 @@ public class DefaultGetRootFolderUseCase extends GetRootFolderUseCase {
         return GetRootFolderOutput.from(
                 folder,
                 this.folderGateway.findByParentFolderIdWithMemberAccess(folder.getId(), owner),
-                fileGateway.findByFolder(folder.getId()));
+                fileGateway.findAllActiveByFolder(folder.getId()));
 
     }
 

--- a/application/src/main/java/com/callv2/drive/application/folder/retrieve/get/root/DefaultGetRootFolderUseCase.java
+++ b/application/src/main/java/com/callv2/drive/application/folder/retrieve/get/root/DefaultGetRootFolderUseCase.java
@@ -50,7 +50,7 @@ public class DefaultGetRootFolderUseCase extends GetRootFolderUseCase {
 
         return GetRootFolderOutput.from(
                 folder,
-                this.folderGateway.findByParentFolderId(folder.getId()),
+                this.folderGateway.findByParentFolderIdWithMemberAccess(folder.getId(), owner),
                 fileGateway.findByFolder(folder.getId()));
 
     }

--- a/application/src/main/java/com/callv2/drive/application/folder/retrieve/get/root/DefaultGetRootFolderUseCase.java
+++ b/application/src/main/java/com/callv2/drive/application/folder/retrieve/get/root/DefaultGetRootFolderUseCase.java
@@ -45,7 +45,7 @@ public class DefaultGetRootFolderUseCase extends GetRootFolderUseCase {
         if (!memberGateway.existsById(owner))
             throw NotFoundException.with(Member.class, owner.getValue().toString());
 
-        final Optional<Folder> root = folderGateway.findRoot(owner);
+        final Optional<Folder> root = folderGateway.findMemberRootFolder(owner);
         final Folder folder = root.isPresent() ? root.get() : createRoot(owner);
 
         return GetRootFolderOutput.from(

--- a/application/src/main/java/com/callv2/drive/application/folder/retrieve/get/root/DefaultGetRootFolderUseCase.java
+++ b/application/src/main/java/com/callv2/drive/application/folder/retrieve/get/root/DefaultGetRootFolderUseCase.java
@@ -3,6 +3,9 @@ package com.callv2.drive.application.folder.retrieve.get.root;
 import java.util.Objects;
 import java.util.Optional;
 
+import com.callv2.drive.domain.access.Acl;
+import com.callv2.drive.domain.access.AclGateway;
+import com.callv2.drive.domain.access.Resource;
 import com.callv2.drive.domain.exception.NotFoundException;
 import com.callv2.drive.domain.file.FileGateway;
 import com.callv2.drive.domain.folder.Folder;
@@ -13,14 +16,17 @@ import com.callv2.drive.domain.member.MemberID;
 
 public class DefaultGetRootFolderUseCase extends GetRootFolderUseCase {
 
+    private final AclGateway aclGateway;
     private final MemberGateway memberGateway;
     private final FolderGateway folderGateway;
     private final FileGateway fileGateway;
 
     public DefaultGetRootFolderUseCase(
+            final AclGateway aclGateway,
             final MemberGateway memberGateway,
             final FolderGateway folderGateway,
             final FileGateway fileGateway) {
+        this.aclGateway = Objects.requireNonNull(aclGateway);
         this.memberGateway = Objects.requireNonNull(memberGateway);
         this.folderGateway = Objects.requireNonNull(folderGateway);
         this.fileGateway = Objects.requireNonNull(fileGateway);
@@ -34,13 +40,22 @@ public class DefaultGetRootFolderUseCase extends GetRootFolderUseCase {
         if (!memberGateway.existsById(owner))
             throw NotFoundException.with(Member.class, owner.getValue().toString());
 
-        final Optional<Folder> root = folderGateway.findRoot();
-        final Folder folder = root.isPresent() ? root.get() : folderGateway.create(Folder.createRoot(owner));
+        final Optional<Folder> root = folderGateway.findRoot(owner);
+        final Folder folder = root.isPresent() ? root.get() : createRoot(owner);
 
         return GetRootFolderOutput.from(
                 folder,
                 this.folderGateway.findByParentFolderId(folder.getId()),
                 fileGateway.findByFolder(folder.getId()));
+
+    }
+
+    private Folder createRoot(final MemberID owner) {
+
+        final Folder root = Folder.createRoot(owner);
+        this.aclGateway.create(Acl.create(Resource.folder(root.getId())).grantTotal(owner));
+        return folderGateway.create(root);
+
     }
 
 }

--- a/application/src/main/java/com/callv2/drive/application/folder/retrieve/get/root/DefaultGetRootFolderUseCase.java
+++ b/application/src/main/java/com/callv2/drive/application/folder/retrieve/get/root/DefaultGetRootFolderUseCase.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import com.callv2.drive.domain.access.Acl;
 import com.callv2.drive.domain.access.AclGateway;
 import com.callv2.drive.domain.access.Resource;
+import com.callv2.drive.domain.event.EventDispatcher;
 import com.callv2.drive.domain.exception.NotFoundException;
 import com.callv2.drive.domain.file.FileGateway;
 import com.callv2.drive.domain.folder.Folder;
@@ -16,16 +17,20 @@ import com.callv2.drive.domain.member.MemberID;
 
 public class DefaultGetRootFolderUseCase extends GetRootFolderUseCase {
 
+    private final EventDispatcher eventDispatcher;
+
     private final AclGateway aclGateway;
     private final MemberGateway memberGateway;
     private final FolderGateway folderGateway;
     private final FileGateway fileGateway;
 
     public DefaultGetRootFolderUseCase(
+            final EventDispatcher eventDispatcher,
             final AclGateway aclGateway,
             final MemberGateway memberGateway,
             final FolderGateway folderGateway,
             final FileGateway fileGateway) {
+        this.eventDispatcher = Objects.requireNonNull(eventDispatcher);
         this.aclGateway = Objects.requireNonNull(aclGateway);
         this.memberGateway = Objects.requireNonNull(memberGateway);
         this.folderGateway = Objects.requireNonNull(folderGateway);
@@ -53,7 +58,7 @@ public class DefaultGetRootFolderUseCase extends GetRootFolderUseCase {
     private Folder createRoot(final MemberID owner) {
 
         final Folder root = Folder.createRoot(owner);
-        this.aclGateway.create(Acl.create(Resource.folder(root.getId())).grantTotal(owner));
+        eventDispatcher.notify(aclGateway.create(Acl.create(Resource.folder(root.getId())).grantTotal(owner)));
         return folderGateway.create(root);
 
     }

--- a/application/src/main/java/com/callv2/drive/application/folder/retrieve/get/root/GetRootFolderInput.java
+++ b/application/src/main/java/com/callv2/drive/application/folder/retrieve/get/root/GetRootFolderInput.java
@@ -1,7 +1,10 @@
 package com.callv2.drive.application.folder.retrieve.get.root;
-public record GetRootFolderInput(String ownerId) {
 
-    public static GetRootFolderInput from(final String ownerId) {
+import java.util.UUID;
+
+public record GetRootFolderInput(UUID ownerId) {
+
+    public static GetRootFolderInput from(final UUID ownerId) {
         return new GetRootFolderInput(ownerId);
     }
 

--- a/application/src/main/java/com/callv2/drive/application/folder/retrieve/get/root/GetRootFolderOutput.java
+++ b/application/src/main/java/com/callv2/drive/application/folder/retrieve/get/root/GetRootFolderOutput.java
@@ -12,7 +12,7 @@ public record GetRootFolderOutput(
         String name,
         List<GetRootFolderOutput.SubFolder> subFolders,
         List<GetRootFolderOutput.File> files,
-        String ownerId,
+        UUID ownerId,
         Instant createdAt,
         Instant updatedAt) {
 

--- a/application/src/main/java/com/callv2/drive/application/folder/retrieve/list/DefaultListFoldersUseCase.java
+++ b/application/src/main/java/com/callv2/drive/application/folder/retrieve/list/DefaultListFoldersUseCase.java
@@ -3,8 +3,8 @@ package com.callv2.drive.application.folder.retrieve.list;
 import java.util.Objects;
 
 import com.callv2.drive.domain.folder.FolderGateway;
+import com.callv2.drive.domain.member.MemberID;
 import com.callv2.drive.domain.pagination.Page;
-import com.callv2.drive.domain.pagination.SearchQuery;
 
 public class DefaultListFoldersUseCase extends ListFoldersUseCase {
 
@@ -15,9 +15,9 @@ public class DefaultListFoldersUseCase extends ListFoldersUseCase {
     }
 
     @Override
-    public Page<FolderListOutput> execute(final SearchQuery input) {
+    public Page<FolderListOutput> execute(final FolderListInput input) {
         return folderGateway
-                .findAll(input)
+                .findAllWithMemberAccess(input.searchQuery(), MemberID.of(input.actorId()))
                 .map(FolderListOutput::from);
     }
 

--- a/application/src/main/java/com/callv2/drive/application/folder/retrieve/list/FolderListInput.java
+++ b/application/src/main/java/com/callv2/drive/application/folder/retrieve/list/FolderListInput.java
@@ -1,0 +1,11 @@
+package com.callv2.drive.application.folder.retrieve.list;
+
+import java.util.UUID;
+
+import com.callv2.drive.domain.pagination.SearchQuery;
+
+public record FolderListInput(
+        UUID actorId,
+        SearchQuery searchQuery) {
+
+}

--- a/application/src/main/java/com/callv2/drive/application/folder/retrieve/list/ListFoldersUseCase.java
+++ b/application/src/main/java/com/callv2/drive/application/folder/retrieve/list/ListFoldersUseCase.java
@@ -2,8 +2,7 @@ package com.callv2.drive.application.folder.retrieve.list;
 
 import com.callv2.drive.application.UseCase;
 import com.callv2.drive.domain.pagination.Page;
-import com.callv2.drive.domain.pagination.SearchQuery;
 
-public abstract class ListFoldersUseCase extends UseCase<SearchQuery, Page<FolderListOutput>> {
+public abstract class ListFoldersUseCase extends UseCase<FolderListInput, Page<FolderListOutput>> {
 
 }

--- a/application/src/main/java/com/callv2/drive/application/folder/update/name/DefaultUpdateFolderNameUseCase.java
+++ b/application/src/main/java/com/callv2/drive/application/folder/update/name/DefaultUpdateFolderNameUseCase.java
@@ -23,15 +23,19 @@ public class DefaultUpdateFolderNameUseCase extends UpdateFolderNameUseCase {
     @Override
     public void execute(final UpdateFolderNameInput input) {
 
+        final MemberID actorId = MemberID.of(input.actorId());
+
         final Folder folder = this.folderGateway
-                .findByIdWithMemberAccess(FolderID.of(input.folderId()), MemberID.of(input.actorId()))
+                .findByIdWithMemberAccess(FolderID.of(input.folderId()), actorId)
                 .orElseThrow(() -> NotFoundException.with(Folder.class, input.folderId().toString()));
 
         final FolderName folderName = FolderName.of(input.name());
 
         final Notification notification = Notification.create();
 
-        final Set<Folder> subFolders = folderGateway.findByParentFolderId(folder.getParentFolder());
+        final Set<Folder> subFolders = folderGateway.findByParentFolderIdWithMemberAccess(
+                folder.getParentFolder(),
+                actorId);
 
         if (subFolders.stream().anyMatch(subFolder -> subFolder.getName().equals(folderName)))
             notification.append(ValidationError.with("Folder with the same name already exists"));

--- a/application/src/main/java/com/callv2/drive/application/folder/update/name/DefaultUpdateFolderNameUseCase.java
+++ b/application/src/main/java/com/callv2/drive/application/folder/update/name/DefaultUpdateFolderNameUseCase.java
@@ -8,6 +8,7 @@ import com.callv2.drive.domain.folder.Folder;
 import com.callv2.drive.domain.folder.FolderGateway;
 import com.callv2.drive.domain.folder.FolderID;
 import com.callv2.drive.domain.folder.FolderName;
+import com.callv2.drive.domain.member.MemberID;
 import com.callv2.drive.domain.validation.ValidationError;
 import com.callv2.drive.domain.validation.handler.Notification;
 
@@ -23,7 +24,7 @@ public class DefaultUpdateFolderNameUseCase extends UpdateFolderNameUseCase {
     public void execute(final UpdateFolderNameInput input) {
 
         final Folder folder = this.folderGateway
-                .findById(FolderID.of(input.folderId()))
+                .findByIdWithMemberAccess(FolderID.of(input.folderId()), MemberID.of(input.actorId()))
                 .orElseThrow(() -> NotFoundException.with(Folder.class, input.folderId().toString()));
 
         final FolderName folderName = FolderName.of(input.name());

--- a/application/src/main/java/com/callv2/drive/application/folder/update/name/UpdateFolderNameInput.java
+++ b/application/src/main/java/com/callv2/drive/application/folder/update/name/UpdateFolderNameInput.java
@@ -4,10 +4,11 @@ import java.util.UUID;
 
 public record UpdateFolderNameInput(
         UUID folderId,
-        String name) {
+        String name,
+        UUID actorId) {
 
-    public static UpdateFolderNameInput of(final UUID folderId, final String name) {
-        return new UpdateFolderNameInput(folderId, name);
+    public static UpdateFolderNameInput of(final UUID folderId, final String name, final UUID actorId) {
+        return new UpdateFolderNameInput(folderId, name, actorId);
     }
 
 }

--- a/application/src/main/java/com/callv2/drive/application/member/quota/request/approve/ApproveRequestQuotaInput.java
+++ b/application/src/main/java/com/callv2/drive/application/member/quota/request/approve/ApproveRequestQuotaInput.java
@@ -1,8 +1,10 @@
 package com.callv2.drive.application.member.quota.request.approve;
 
-public record ApproveRequestQuotaInput(String memberId, boolean approved) {
+import java.util.UUID;
 
-    public static ApproveRequestQuotaInput of(String memberId, boolean approved) {
+public record ApproveRequestQuotaInput(UUID memberId, boolean approved) {
+
+    public static ApproveRequestQuotaInput of(UUID memberId, boolean approved) {
         return new ApproveRequestQuotaInput(memberId, approved);
     }
 

--- a/application/src/main/java/com/callv2/drive/application/member/quota/request/approve/DefaultApproveRequestQuotaUseCase.java
+++ b/application/src/main/java/com/callv2/drive/application/member/quota/request/approve/DefaultApproveRequestQuotaUseCase.java
@@ -20,7 +20,7 @@ public class DefaultApproveRequestQuotaUseCase extends ApproveRequestQuotaUseCas
 
         final Member member = memberGateway
                 .findById(MemberID.of(input.memberId()))
-                .orElseThrow(() -> NotFoundException.with(Member.class, input.memberId()));
+                .orElseThrow(() -> NotFoundException.with(Member.class, input.memberId().toString()));
 
         if (input.approved())
             member.approveQuotaRequest();

--- a/application/src/main/java/com/callv2/drive/application/member/quota/request/create/CreateRequestQuotaInput.java
+++ b/application/src/main/java/com/callv2/drive/application/member/quota/request/create/CreateRequestQuotaInput.java
@@ -1,10 +1,12 @@
 package com.callv2.drive.application.member.quota.request.create;
 
+import java.util.UUID;
+
 import com.callv2.drive.domain.member.QuotaUnit;
 
-public record CreateRequestQuotaInput(String memberId, Long amount, QuotaUnit unit) {
+public record CreateRequestQuotaInput(UUID memberId, Long amount, QuotaUnit unit) {
 
-    public static CreateRequestQuotaInput of(String memberId, Long amount, QuotaUnit unit) {
+    public static CreateRequestQuotaInput of(UUID memberId, Long amount, QuotaUnit unit) {
         return new CreateRequestQuotaInput(memberId, amount, unit);
     }
 

--- a/application/src/main/java/com/callv2/drive/application/member/quota/request/create/DefaultCreateRequestQuotaUseCase.java
+++ b/application/src/main/java/com/callv2/drive/application/member/quota/request/create/DefaultCreateRequestQuotaUseCase.java
@@ -25,7 +25,7 @@ public class DefaultCreateRequestQuotaUseCase extends CreateRequestQuotaUseCase 
 
         final Member member = memberGateway
                 .findById(memberId)
-                .orElseThrow(() -> NotFoundException.with(Member.class, input.memberId()));
+                .orElseThrow(() -> NotFoundException.with(Member.class, input.memberId().toString()));
 
         final Notification notification = Notification.create();
         notification.validate(() -> member.requestQuota(Quota.of(input.amount(), input.unit())));

--- a/application/src/main/java/com/callv2/drive/application/member/quota/request/list/ListRequestQuotaOutput.java
+++ b/application/src/main/java/com/callv2/drive/application/member/quota/request/list/ListRequestQuotaOutput.java
@@ -1,12 +1,13 @@
 package com.callv2.drive.application.member.quota.request.list;
 
 import java.time.Instant;
+import java.util.UUID;
 
 import com.callv2.drive.domain.member.QuotaRequestPreview;
 import com.callv2.drive.domain.member.QuotaUnit;
 
 public record ListRequestQuotaOutput(
-        String memberId,
+        UUID memberId,
         String memberUsername,
         String memberNickname,
         long quotaAmount,

--- a/application/src/main/java/com/callv2/drive/application/member/quota/retrieve/get/GetQuotaInput.java
+++ b/application/src/main/java/com/callv2/drive/application/member/quota/retrieve/get/GetQuotaInput.java
@@ -1,8 +1,10 @@
 package com.callv2.drive.application.member.quota.retrieve.get;
 
-public record GetQuotaInput(String memberId) {
+import java.util.UUID;
 
-    public static GetQuotaInput of(final String memberId) {
+public record GetQuotaInput(UUID memberId) {
+
+    public static GetQuotaInput of(final UUID memberId) {
         return new GetQuotaInput(memberId);
     }
 

--- a/application/src/main/java/com/callv2/drive/application/member/quota/retrieve/get/GetQuotaOutput.java
+++ b/application/src/main/java/com/callv2/drive/application/member/quota/retrieve/get/GetQuotaOutput.java
@@ -1,8 +1,10 @@
 package com.callv2.drive.application.member.quota.retrieve.get;
 
+import java.util.UUID;
+
 import com.callv2.drive.domain.member.Member;
 
-public record GetQuotaOutput(String memberId, String username, Long used, Long total, Long available) {
+public record GetQuotaOutput(UUID memberId, String username, Long used, Long total, Long available) {
 
     public static GetQuotaOutput from(final Member member, final Long usedQuotaInBytes) {
         return new GetQuotaOutput(

--- a/application/src/main/java/com/callv2/drive/application/member/quota/retrieve/list/ListQuotaOutput.java
+++ b/application/src/main/java/com/callv2/drive/application/member/quota/retrieve/list/ListQuotaOutput.java
@@ -1,8 +1,10 @@
 package com.callv2.drive.application.member.quota.retrieve.list;
 
+import java.util.UUID;
+
 import com.callv2.drive.domain.member.Member;
 
-public record ListQuotaOutput(String memberId, String username, Long total) {
+public record ListQuotaOutput(UUID memberId, String username, Long total) {
 
     public static ListQuotaOutput of(final Member member) {
         return new ListQuotaOutput(

--- a/application/src/main/java/com/callv2/drive/application/member/synchronize/SynchronizeMemberInput.java
+++ b/application/src/main/java/com/callv2/drive/application/member/synchronize/SynchronizeMemberInput.java
@@ -1,9 +1,10 @@
 package com.callv2.drive.application.member.synchronize;
 
 import java.time.Instant;
+import java.util.UUID;
 
 public record SynchronizeMemberInput(
-        String id,
+        UUID id,
         String username,
         String nickname,
         Boolean hasSystemAccess,
@@ -12,7 +13,7 @@ public record SynchronizeMemberInput(
         Long synchronizedVersion) {
 
     public static SynchronizeMemberInput from(
-            final String id,
+            final UUID id,
             final String username,
             final String nickname,
             final Boolean hasSystemAccess,

--- a/application/src/test/java/com/callv2/drive/application/file/content/get/DefaultGetFileContentUseCaseTest.java
+++ b/application/src/test/java/com/callv2/drive/application/file/content/get/DefaultGetFileContentUseCaseTest.java
@@ -52,13 +52,13 @@ public class DefaultGetFileContentUseCaseTest {
         final var expectedFileId = expectedFile.getId();
         final var expectedInputStream = new ByteArrayInputStream(new byte[] {});
 
-        when(fileGateway.findById(any()))
+        when(fileGateway.findByIdWithMemberAccess(any(), any()))
                 .thenReturn(Optional.of(expectedFile));
 
         when(storageService.retrieve(expectedContent.storageKey()))
                 .thenReturn(expectedInputStream);
 
-        final var input = GetFileContentInput.with(expectedFileId.getValue());
+        final var input = GetFileContentInput.with(expectedFileId.getValue(), creatorId.getValue());
 
         final var actualOutput = useCase.execute(input);
 
@@ -66,13 +66,15 @@ public class DefaultGetFileContentUseCaseTest {
         assertEquals(expectedContent.size(), actualOutput.size());
         assertEquals(expectedInputStream, actualOutput.inputStream());
 
-        verify(fileGateway, times(1)).findById(any());
-        verify(fileGateway, times(1)).findById(eq(expectedFileId));
+        verify(fileGateway, times(1)).findByIdWithMemberAccess(any(), any());
+        verify(fileGateway, times(1)).findByIdWithMemberAccess(eq(expectedFileId), eq(creatorId));
 
     }
 
     @Test
     void givenAnInexistentId_whenCallsExecute_shouldThrowNotFoundException() {
+
+        final var actorId = MemberID.of(UUID.randomUUID());
 
         final var expectedFileId = FileID.unique();
 
@@ -80,10 +82,10 @@ public class DefaultGetFileContentUseCaseTest {
         final var expectedErrorsCount = 1;
         final var expectedErrorMessage = "[File] with id [%s] not found.".formatted(expectedFileId.getValue());
 
-        when(fileGateway.findById(any()))
+        when(fileGateway.findByIdWithMemberAccess(any(), any()))
                 .thenReturn(Optional.empty());
 
-        final var input = GetFileContentInput.with(expectedFileId.getValue());
+        final var input = GetFileContentInput.with(expectedFileId.getValue(), actorId.getValue());
 
         final var actualException = assertThrows(NotFoundException.class, () -> useCase.execute(input));
 
@@ -91,8 +93,8 @@ public class DefaultGetFileContentUseCaseTest {
         assertEquals(expectedErrorsCount, actualException.getErrors().size());
         assertEquals(expectedErrorMessage, actualException.getErrors().get(0).message());
 
-        verify(fileGateway, times(1)).findById(any());
-        verify(fileGateway, times(1)).findById(eq(expectedFileId));
+        verify(fileGateway, times(1)).findByIdWithMemberAccess(any(), any());
+        verify(fileGateway, times(1)).findByIdWithMemberAccess(eq(expectedFileId), eq(actorId));
 
     }
 

--- a/application/src/test/java/com/callv2/drive/application/file/content/get/DefaultGetFileContentUseCaseTest.java
+++ b/application/src/test/java/com/callv2/drive/application/file/content/get/DefaultGetFileContentUseCaseTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.when;
 
 import java.io.ByteArrayInputStream;
 import java.util.Optional;
+import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -25,7 +26,7 @@ import com.callv2.drive.domain.file.FileID;
 import com.callv2.drive.domain.file.FileName;
 import com.callv2.drive.domain.folder.FolderID;
 import com.callv2.drive.domain.member.MemberID;
-import com.callv2.drive.domain.storage.StorageService;
+import com.callv2.drive.domain.storage.StorageGateway;
 
 @ExtendWith(MockitoExtension.class)
 public class DefaultGetFileContentUseCaseTest {
@@ -37,16 +38,17 @@ public class DefaultGetFileContentUseCaseTest {
     FileGateway fileGateway;
 
     @Mock
-    StorageService storageService;
+    StorageGateway storageService;
 
     @Test
     void givenAValidParam_whenCallsExecute_shouldReturnContent() {
 
-        final var ownerId = MemberID.of("owner");
+        final var creatorId = MemberID.of(UUID.randomUUID());
+        final var ownerId = MemberID.of(UUID.randomUUID());
         final var expectedFolder = FolderID.unique();
         final var expectedFileName = FileName.of("file.txt");
         final var expectedContent = Content.of("key", "text", 10);
-        final var expectedFile = File.create(ownerId, expectedFolder, expectedFileName, expectedContent);
+        final var expectedFile = File.create(creatorId, ownerId, expectedFolder, expectedFileName, expectedContent);
         final var expectedFileId = expectedFile.getId();
         final var expectedInputStream = new ByteArrayInputStream(new byte[] {});
 

--- a/application/src/test/java/com/callv2/drive/application/file/create/DefaultCreateFileUseCaseTest.java
+++ b/application/src/test/java/com/callv2/drive/application/file/create/DefaultCreateFileUseCaseTest.java
@@ -17,6 +17,7 @@ import java.io.ByteArrayInputStream;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -42,7 +43,7 @@ import com.callv2.drive.domain.member.Nickname;
 import com.callv2.drive.domain.member.Quota;
 import com.callv2.drive.domain.member.QuotaUnit;
 import com.callv2.drive.domain.member.Username;
-import com.callv2.drive.domain.storage.StorageService;
+import com.callv2.drive.domain.storage.StorageGateway;
 
 @ExtendWith(MockitoExtension.class)
 class DefaultCreateFileUseCaseTest {
@@ -57,7 +58,7 @@ class DefaultCreateFileUseCaseTest {
     FolderGateway folderGateway;
 
     @Mock
-    StorageService storageService;
+    StorageGateway storageService;
 
     @Mock
     FileGateway fileGateway;
@@ -66,7 +67,7 @@ class DefaultCreateFileUseCaseTest {
     void givenAValidParams_whenCallsExecute_thenShouldCreateFile() {
 
         final var owner = Member.with(
-                MemberID.of("owner"),
+                MemberID.of(UUID.randomUUID()),
                 Username.of("username"),
                 Nickname.of("nickname"),
                 Quota.of(0, QuotaUnit.BYTE),
@@ -144,7 +145,7 @@ class DefaultCreateFileUseCaseTest {
     void givenAnInvalidFolderId_whenCallsExecute_thenShouldThrowNotFoundException() {
 
         final var owner = Member.with(
-                MemberID.of("owner"),
+                MemberID.of(UUID.randomUUID()),
                 Username.of("username"),
                 Nickname.of("nickname"),
                 Quota.of(0, QuotaUnit.BYTE),
@@ -207,7 +208,7 @@ class DefaultCreateFileUseCaseTest {
     @Test
     void givenAnInvalidMemberId_whenCallsExecute_thenShouldThrowNotFoundException() {
 
-        final var expectedOwnerId = MemberID.of("inexistent");
+        final var expectedOwnerId = MemberID.of(UUID.randomUUID());
         final var expectedFolderId = FolderID.unique();
 
         final var expectedFileName = FileName.of("file");
@@ -253,8 +254,19 @@ class DefaultCreateFileUseCaseTest {
     @Test
     void givenAValidParamsWithAlreadyExistingFileNameOnSameFolder_whenCallsExecute_thenShouldThrowValidationException() {
 
+        final var creator = Member.with(
+                MemberID.of(UUID.randomUUID()),
+                Username.of("creator"),
+                Nickname.of("creator"),
+                Quota.of(0, QuotaUnit.BYTE),
+                null,
+                true,
+                Instant.now(),
+                Instant.now(),
+                0L);
+
         final var owner = Member.with(
-                MemberID.of("owner"),
+                MemberID.of(UUID.randomUUID()),
                 Username.of("username"),
                 Nickname.of("nickname"),
                 Quota.of(0, QuotaUnit.BYTE),
@@ -266,6 +278,7 @@ class DefaultCreateFileUseCaseTest {
                 .requestQuota(Quota.of(1, QuotaUnit.GIGABYTE))
                 .approveQuotaRequest();
 
+        final var creatorId = creator.getId();
         final var ownerId = owner.getId();
 
         final var folder = Folder.createRoot(ownerId);
@@ -279,7 +292,7 @@ class DefaultCreateFileUseCaseTest {
         final var expectedContent = new ByteArrayInputStream(contentBytes);
         final var expectedContentSize = (long) contentBytes.length;
 
-        final var fileWithSameName = File.create(ownerId, folder.getId(), expectedFileName,
+        final var fileWithSameName = File.create(creatorId, ownerId, folder.getId(), expectedFileName,
                 Content.of("location", "text", 10));
 
         final var expectedExceptionMessage = "Could not create Aggregate File";
@@ -321,7 +334,7 @@ class DefaultCreateFileUseCaseTest {
     void givenAValidParams_whenCallsExecuteAndFileGatewayCreateThrowsRandomException_thenShouldThrowInternalErrorException() {
 
         final var owner = Member.with(
-                MemberID.of("owner"),
+                MemberID.of(UUID.randomUUID()),
                 Username.of("username"),
                 Nickname.of("nickname"),
                 Quota.of(0, QuotaUnit.BYTE),
@@ -406,7 +419,7 @@ class DefaultCreateFileUseCaseTest {
     void givenAValidParams_whenCallsExecuteAndFileGatewayCreateAndContentGatewayDeleteThrowsRandomException_thenShouldThrowInternalErrorException() {
 
         final var owner = Member.with(
-                MemberID.of("owner"),
+                MemberID.of(UUID.randomUUID()),
                 Username.of("username"),
                 Nickname.of("nickname"),
                 Quota.of(0, QuotaUnit.BYTE),
@@ -491,7 +504,7 @@ class DefaultCreateFileUseCaseTest {
     void givenAValidParams_whenCallsExecuteAndContentGatewayStoreThrowsRandomException_thenShouldThrowInternalErrorException() {
 
         final var owner = Member.with(
-                MemberID.of("owner"),
+                MemberID.of(UUID.randomUUID()),
                 Username.of("username"),
                 Nickname.of("nickname"),
                 Quota.of(0, QuotaUnit.BYTE),
@@ -555,7 +568,7 @@ class DefaultCreateFileUseCaseTest {
     void givenAnInvalidFileName_whenCallsExecute_thenShouldThrowValidationException() {
 
         final var owner = Member.with(
-                MemberID.of("owner"),
+                MemberID.of(UUID.randomUUID()),
                 Username.of("username"),
                 Nickname.of("nickname"),
                 Quota.of(0, QuotaUnit.BYTE),
@@ -616,7 +629,7 @@ class DefaultCreateFileUseCaseTest {
     void givenAValidParams_whenCallsExecuteAndMemberQuotaIsExceeded_thenShouldThrowsQuotaExceededException() {
 
         final var owner = Member.with(
-                MemberID.of("owner"),
+                MemberID.of(UUID.randomUUID()),
                 Username.of("username"),
                 Nickname.of("nickname"),
                 Quota.of(0, QuotaUnit.BYTE),
@@ -673,7 +686,7 @@ class DefaultCreateFileUseCaseTest {
     void givenAnInvalidParamsWithContentTypeNull_whenCallsExecute_thenShouldThrowsValidationException() {
 
         final var owner = Member.with(
-                MemberID.of("owner"),
+                MemberID.of(UUID.randomUUID()),
                 Username.of("username"),
                 Nickname.of("nickname"),
                 Quota.of(0, QuotaUnit.BYTE),

--- a/application/src/test/java/com/callv2/drive/application/file/create/DefaultCreateFileUseCaseTest.java
+++ b/application/src/test/java/com/callv2/drive/application/file/create/DefaultCreateFileUseCaseTest.java
@@ -219,7 +219,7 @@ class DefaultCreateFileUseCaseTest {
         when(memberGateway.findById(any()))
                 .thenReturn(Optional.of(owner));
 
-        when(folderGateway.findByIdWithMemberAccess(any(), ownerId))
+        when(folderGateway.findByIdWithMemberAccess(any(), any()))
                 .thenReturn(Optional.empty());
 
         final var input = CreateFileInput.of(

--- a/application/src/test/java/com/callv2/drive/application/file/create/DefaultCreateFileUseCaseTest.java
+++ b/application/src/test/java/com/callv2/drive/application/file/create/DefaultCreateFileUseCaseTest.java
@@ -123,7 +123,7 @@ class DefaultCreateFileUseCaseTest {
         when(memberGateway.findById(any()))
                 .thenReturn(Optional.of(owner));
 
-        when(fileGateway.findByFolder(any()))
+        when(fileGateway.findAllActiveByFolder(any()))
                 .thenReturn(List.of());
 
         when(folderGateway.findByIdWithMemberAccess(any(), any()))
@@ -164,8 +164,8 @@ class DefaultCreateFileUseCaseTest {
         verify(storageService, times(1)).store(any(), any());
         verify(storageService, times(1)).store(any(), eq(expectedContent));
         verify(storageService, times(0)).delete(any());
-        verify(fileGateway, times(1)).findByFolder(any());
-        verify(fileGateway, times(1)).findByFolder(eq(folder.getId()));
+        verify(fileGateway, times(1)).findAllActiveByFolder(any());
+        verify(fileGateway, times(1)).findAllActiveByFolder(eq(folder.getId()));
         verify(fileGateway, times(1)).create(any());
         verify(fileGateway, times(1)).create(argThat(file -> {
 
@@ -241,7 +241,7 @@ class DefaultCreateFileUseCaseTest {
         verify(storageService, times(0)).store(any(), any());
         verify(storageService, times(0)).store(any(), eq(expectedContent));
         verify(storageService, times(0)).delete(any());
-        verify(fileGateway, times(0)).findByFolder(any());
+        verify(fileGateway, times(0)).findAllActiveByFolder(any());
         verify(fileGateway, times(0)).create(any());
 
     }
@@ -287,7 +287,7 @@ class DefaultCreateFileUseCaseTest {
         verify(storageService, times(0)).store(any(), any());
         verify(storageService, times(0)).store(any(), eq(expectedContent));
         verify(storageService, times(0)).delete(any());
-        verify(fileGateway, times(0)).findByFolder(any());
+        verify(fileGateway, times(0)).findAllActiveByFolder(any());
         verify(fileGateway, times(0)).create(any());
 
     }
@@ -350,7 +350,7 @@ class DefaultCreateFileUseCaseTest {
         when(memberGateway.findById(ownerId))
                 .thenReturn(Optional.of(owner));
 
-        when(fileGateway.findByFolder(any()))
+        when(fileGateway.findAllActiveByFolder(any()))
                 .thenReturn(List.of(fileWithSameName));
 
         when(folderGateway.findByIdWithMemberAccess(any(), any()))
@@ -382,8 +382,8 @@ class DefaultCreateFileUseCaseTest {
         verify(folderGateway, times(1)).findByIdWithMemberAccess(eq(expectedFolderId), eq(ownerId));
         verify(storageService, times(0)).store(any(), any());
         verify(storageService, times(0)).delete(any());
-        verify(fileGateway, times(1)).findByFolder(any());
-        verify(fileGateway, times(1)).findByFolder(eq(folder.getId()));
+        verify(fileGateway, times(1)).findAllActiveByFolder(any());
+        verify(fileGateway, times(1)).findAllActiveByFolder(eq(folder.getId()));
         verify(fileGateway, times(0)).create(any());
 
     }
@@ -431,7 +431,7 @@ class DefaultCreateFileUseCaseTest {
         when(memberGateway.findById(ownerId))
                 .thenReturn(Optional.of(owner));
 
-        when(fileGateway.findByFolder(any()))
+        when(fileGateway.findAllActiveByFolder(any()))
                 .thenReturn(List.of());
 
         when(folderGateway.findByIdWithMemberAccess(any(), any()))
@@ -477,8 +477,8 @@ class DefaultCreateFileUseCaseTest {
         verify(storageService, times(1)).store(any(), any());
         verify(storageService, times(1)).store(any(), eq(expectedContent));
         verify(storageService, times(1)).delete(any());
-        verify(fileGateway, times(1)).findByFolder(any());
-        verify(fileGateway, times(1)).findByFolder(eq(folder.getId()));
+        verify(fileGateway, times(1)).findAllActiveByFolder(any());
+        verify(fileGateway, times(1)).findAllActiveByFolder(eq(folder.getId()));
         verify(fileGateway, times(1)).create(any());
         verify(fileGateway, times(1)).create(argThat(file -> {
 
@@ -538,7 +538,7 @@ class DefaultCreateFileUseCaseTest {
         when(memberGateway.findById(ownerId))
                 .thenReturn(Optional.of(owner));
 
-        when(fileGateway.findByFolder(any()))
+        when(fileGateway.findAllActiveByFolder(any()))
                 .thenReturn(List.of());
 
         when(folderGateway.findByIdWithMemberAccess(any(), any()))
@@ -584,8 +584,8 @@ class DefaultCreateFileUseCaseTest {
         verify(storageService, times(1)).store(any(), any());
         verify(storageService, times(1)).store(any(), eq(expectedContent));
         verify(storageService, times(1)).delete(any());
-        verify(fileGateway, times(1)).findByFolder(any());
-        verify(fileGateway, times(1)).findByFolder(eq(folder.getId()));
+        verify(fileGateway, times(1)).findAllActiveByFolder(any());
+        verify(fileGateway, times(1)).findAllActiveByFolder(eq(folder.getId()));
         verify(fileGateway, times(1)).create(any());
         verify(fileGateway, times(1)).create(argThat(file -> {
 
@@ -681,8 +681,8 @@ class DefaultCreateFileUseCaseTest {
         verify(folderGateway, times(1)).findByIdWithMemberAccess(eq(expectedFolderId), eq(ownerId));
         verify(storageService, times(1)).store(any(), any());
         verify(storageService, times(1)).store(any(), eq(expectedContent));
-        verify(fileGateway, times(1)).findByFolder(any());
-        verify(fileGateway, times(1)).findByFolder(eq(expectedFolderId));
+        verify(fileGateway, times(1)).findAllActiveByFolder(any());
+        verify(fileGateway, times(1)).findAllActiveByFolder(eq(expectedFolderId));
         verify(storageService, times(0)).delete(any());
         verify(fileGateway, times(0)).create(any());
 
@@ -760,7 +760,7 @@ class DefaultCreateFileUseCaseTest {
         verify(folderGateway, times(1)).findByIdWithMemberAccess(any(), any());
         verify(folderGateway, times(1)).findByIdWithMemberAccess(eq(expectedFolderId), eq(ownerId));
         verify(storageService, times(0)).store(any(), any());
-        verify(fileGateway, times(0)).findByFolder(any());
+        verify(fileGateway, times(0)).findAllActiveByFolder(any());
         verify(storageService, times(0)).delete(any());
         verify(fileGateway, times(0)).create(any());
 
@@ -837,7 +837,7 @@ class DefaultCreateFileUseCaseTest {
 
         verify(folderGateway, times(1)).findByIdWithMemberAccess(any(), any());
         verify(storageService, times(0)).store(any(), any());
-        verify(fileGateway, times(0)).findByFolder(any());
+        verify(fileGateway, times(0)).findAllActiveByFolder(any());
         verify(storageService, times(0)).delete(any());
         verify(fileGateway, times(0)).create(any());
 
@@ -888,7 +888,7 @@ class DefaultCreateFileUseCaseTest {
         when(memberGateway.findById(any()))
                 .thenReturn(Optional.of(owner));
 
-        when(fileGateway.findByFolder(any()))
+        when(fileGateway.findAllActiveByFolder(any()))
                 .thenReturn(List.of());
 
         when(folderGateway.findByIdWithMemberAccess(any(), any()))
@@ -931,8 +931,8 @@ class DefaultCreateFileUseCaseTest {
         verify(storageService, times(1)).store(any(), any());
         verify(storageService, times(1)).store(any(), eq(expectedContent));
         verify(storageService, times(0)).delete(any());
-        verify(fileGateway, times(1)).findByFolder(any());
-        verify(fileGateway, times(1)).findByFolder(eq(folder.getId()));
+        verify(fileGateway, times(1)).findAllActiveByFolder(any());
+        verify(fileGateway, times(1)).findAllActiveByFolder(eq(folder.getId()));
         verify(fileGateway, times(0)).create(any());
 
     }

--- a/application/src/test/java/com/callv2/drive/application/file/create/DefaultCreateFileUseCaseTest.java
+++ b/application/src/test/java/com/callv2/drive/application/file/create/DefaultCreateFileUseCaseTest.java
@@ -17,6 +17,7 @@ import java.io.ByteArrayInputStream;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
@@ -25,6 +26,14 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.callv2.drive.domain.access.AccessPermission;
+import com.callv2.drive.domain.access.Acl;
+import com.callv2.drive.domain.access.AclGateway;
+import com.callv2.drive.domain.access.AclID;
+import com.callv2.drive.domain.access.Entry;
+import com.callv2.drive.domain.access.Resource;
+import com.callv2.drive.domain.access.SharePermission;
+import com.callv2.drive.domain.event.EventDispatcher;
 import com.callv2.drive.domain.exception.InternalErrorException;
 import com.callv2.drive.domain.exception.NotFoundException;
 import com.callv2.drive.domain.exception.QuotaExceededException;
@@ -44,6 +53,7 @@ import com.callv2.drive.domain.member.Quota;
 import com.callv2.drive.domain.member.QuotaUnit;
 import com.callv2.drive.domain.member.Username;
 import com.callv2.drive.domain.storage.StorageGateway;
+import com.callv2.drive.domain.storage.StorageKeyGenerator;
 
 @ExtendWith(MockitoExtension.class)
 class DefaultCreateFileUseCaseTest {
@@ -52,16 +62,25 @@ class DefaultCreateFileUseCaseTest {
     DefaultCreateFileUseCase useCase;
 
     @Mock
+    EventDispatcher eventDispatcher;
+
+    @Mock
     MemberGateway memberGateway;
 
     @Mock
     FolderGateway folderGateway;
 
     @Mock
+    StorageKeyGenerator storageKeyGenerator;
+
+    @Mock
     StorageGateway storageService;
 
     @Mock
     FileGateway fileGateway;
+
+    @Mock
+    AclGateway aclGateway;
 
     @Test
     void givenAValidParams_whenCallsExecute_thenShouldCreateFile() {
@@ -91,14 +110,36 @@ class DefaultCreateFileUseCaseTest {
         final var expectedContent = new ByteArrayInputStream(contentBytes);
         final var expectedContentSize = (long) contentBytes.length;
 
+        final var expectedAclId = AclID.unique();
+        final var expectedAclResource = Resource.folder(expectedFolderId);
+        final var expectedAclDirectEntries = Set.of(Entry.create(ownerId, AccessPermission.mostPrivileged(),
+                SharePermission.mostPrivileged()));
+        final var expectedAclInheritedEntries = Set.<Entry>of();
+        final var expectedAclCreatedAt = Instant.now();
+        final var expectedAclUpdatedAt = expectedAclCreatedAt;
+
+        final var expectedStorageKey = UUID.randomUUID().toString();
+
         when(memberGateway.findById(any()))
                 .thenReturn(Optional.of(owner));
 
         when(fileGateway.findByFolder(any()))
                 .thenReturn(List.of());
 
-        when(folderGateway.findById(any()))
+        when(folderGateway.findByIdWithMemberAccess(any(), any()))
                 .thenReturn(Optional.of(folder));
+
+        when(aclGateway.findByResource(any()))
+                .thenReturn(Optional.of(Acl.with(
+                        expectedAclId,
+                        expectedAclResource,
+                        expectedAclDirectEntries,
+                        expectedAclInheritedEntries,
+                        expectedAclCreatedAt,
+                        expectedAclUpdatedAt)));
+
+        when(storageKeyGenerator.generate())
+                .thenReturn(expectedStorageKey);
 
         doNothing()
                 .when(storageService).store(any(), any());
@@ -118,8 +159,8 @@ class DefaultCreateFileUseCaseTest {
 
         assertNotNull(actualOuptut.id());
 
-        verify(folderGateway, times(1)).findById(any());
-        verify(folderGateway, times(1)).findById(eq(expectedFolderId));
+        verify(folderGateway, times(1)).findByIdWithMemberAccess(any(), any());
+        verify(folderGateway, times(1)).findByIdWithMemberAccess(eq(expectedFolderId), eq(ownerId));
         verify(storageService, times(1)).store(any(), any());
         verify(storageService, times(1)).store(any(), eq(expectedContent));
         verify(storageService, times(0)).delete(any());
@@ -178,7 +219,7 @@ class DefaultCreateFileUseCaseTest {
         when(memberGateway.findById(any()))
                 .thenReturn(Optional.of(owner));
 
-        when(folderGateway.findById(any()))
+        when(folderGateway.findByIdWithMemberAccess(any(), ownerId))
                 .thenReturn(Optional.empty());
 
         final var input = CreateFileInput.of(
@@ -195,8 +236,8 @@ class DefaultCreateFileUseCaseTest {
         assertEquals(expectedErrorCount, actualException.getErrors().size());
         assertEquals(expectedErrorMessage, actualException.getErrors().get(0).message());
 
-        verify(folderGateway, times(1)).findById(any());
-        verify(folderGateway, times(1)).findById(eq(expectedFolderId));
+        verify(folderGateway, times(1)).findByIdWithMemberAccess(any(), any());
+        verify(folderGateway, times(1)).findByIdWithMemberAccess(eq(expectedFolderId), eq(ownerId));
         verify(storageService, times(0)).store(any(), any());
         verify(storageService, times(0)).store(any(), eq(expectedContent));
         verify(storageService, times(0)).delete(any());
@@ -242,7 +283,7 @@ class DefaultCreateFileUseCaseTest {
 
         verify(memberGateway, times(1)).findById(any());
         verify(memberGateway, times(1)).findById(eq(expectedOwnerId));
-        verify(folderGateway, times(0)).findById(any());
+        verify(folderGateway, times(0)).findByIdWithMemberAccess(any(), any());
         verify(storageService, times(0)).store(any(), any());
         verify(storageService, times(0)).store(any(), eq(expectedContent));
         verify(storageService, times(0)).delete(any());
@@ -298,14 +339,31 @@ class DefaultCreateFileUseCaseTest {
         final var expectedExceptionMessage = "Could not create Aggregate File";
         final var expectedErrorMessage = "File with same name already exists on this folder";
 
+        final var expectedAclId = AclID.unique();
+        final var expectedAclResource = Resource.folder(expectedFolderId);
+        final var expectedAclDirectEntries = Set.of(Entry.create(ownerId, AccessPermission.mostPrivileged(),
+                SharePermission.mostPrivileged()));
+        final var expectedAclInheritedEntries = Set.<Entry>of();
+        final var expectedAclCreatedAt = Instant.now();
+        final var expectedAclUpdatedAt = expectedAclCreatedAt;
+
         when(memberGateway.findById(ownerId))
                 .thenReturn(Optional.of(owner));
 
         when(fileGateway.findByFolder(any()))
                 .thenReturn(List.of(fileWithSameName));
 
-        when(folderGateway.findById(any()))
+        when(folderGateway.findByIdWithMemberAccess(any(), any()))
                 .thenReturn(Optional.of(folder));
+
+        when(aclGateway.findByResource(any()))
+                .thenReturn(Optional.of(Acl.with(
+                        expectedAclId,
+                        expectedAclResource,
+                        expectedAclDirectEntries,
+                        expectedAclInheritedEntries,
+                        expectedAclCreatedAt,
+                        expectedAclUpdatedAt)));
 
         final var input = CreateFileInput.of(
                 ownerId.getValue(),
@@ -320,8 +378,8 @@ class DefaultCreateFileUseCaseTest {
         assertEquals(expectedExceptionMessage, actualException.getMessage());
         assertEquals(expectedErrorMessage, actualException.getErrors().get(0).message());
 
-        verify(folderGateway, times(1)).findById(any());
-        verify(folderGateway, times(1)).findById(eq(expectedFolderId));
+        verify(folderGateway, times(1)).findByIdWithMemberAccess(any(), any());
+        verify(folderGateway, times(1)).findByIdWithMemberAccess(eq(expectedFolderId), eq(ownerId));
         verify(storageService, times(0)).store(any(), any());
         verify(storageService, times(0)).delete(any());
         verify(fileGateway, times(1)).findByFolder(any());
@@ -360,13 +418,23 @@ class DefaultCreateFileUseCaseTest {
 
         final var expectedExceptionMessage = "Could not store File";
 
+        final var expectedAclId = AclID.unique();
+        final var expectedAclResource = Resource.folder(expectedFolderId);
+        final var expectedAclDirectEntries = Set.of(Entry.create(ownerId, AccessPermission.mostPrivileged(),
+                SharePermission.mostPrivileged()));
+        final var expectedAclInheritedEntries = Set.<Entry>of();
+        final var expectedAclCreatedAt = Instant.now();
+        final var expectedAclUpdatedAt = expectedAclCreatedAt;
+
+        final var expectedStorageKey = UUID.randomUUID().toString();
+
         when(memberGateway.findById(ownerId))
                 .thenReturn(Optional.of(owner));
 
         when(fileGateway.findByFolder(any()))
                 .thenReturn(List.of());
 
-        when(folderGateway.findById(any()))
+        when(folderGateway.findByIdWithMemberAccess(any(), any()))
                 .thenReturn(Optional.of(folder));
 
         doNothing()
@@ -378,6 +446,18 @@ class DefaultCreateFileUseCaseTest {
         doNothing()
                 .when(storageService)
                 .delete(any());
+
+        when(aclGateway.findByResource(any()))
+                .thenReturn(Optional.of(Acl.with(
+                        expectedAclId,
+                        expectedAclResource,
+                        expectedAclDirectEntries,
+                        expectedAclInheritedEntries,
+                        expectedAclCreatedAt,
+                        expectedAclUpdatedAt)));
+
+        when(storageKeyGenerator.generate())
+                .thenReturn(expectedStorageKey);
 
         final var input = CreateFileInput.of(
                 ownerId.getValue(),
@@ -392,8 +472,8 @@ class DefaultCreateFileUseCaseTest {
         assertEquals(expectedExceptionMessage, actualException.getMessage());
         assertEquals("FileGateway Exception", actualException.getCause().getMessage());
 
-        verify(folderGateway, times(1)).findById(any());
-        verify(folderGateway, times(1)).findById(eq(expectedFolderId));
+        verify(folderGateway, times(1)).findByIdWithMemberAccess(any(), any());
+        verify(folderGateway, times(1)).findByIdWithMemberAccess(eq(expectedFolderId), eq(ownerId));
         verify(storageService, times(1)).store(any(), any());
         verify(storageService, times(1)).store(any(), eq(expectedContent));
         verify(storageService, times(1)).delete(any());
@@ -445,13 +525,23 @@ class DefaultCreateFileUseCaseTest {
 
         final var expectedExceptionMessage = "Could not delete BinaryContent";
 
+        final var expectedAclId = AclID.unique();
+        final var expectedAclResource = Resource.folder(expectedFolderId);
+        final var expectedAclDirectEntries = Set.of(Entry.create(ownerId, AccessPermission.mostPrivileged(),
+                SharePermission.mostPrivileged()));
+        final var expectedAclInheritedEntries = Set.<Entry>of();
+        final var expectedAclCreatedAt = Instant.now();
+        final var expectedAclUpdatedAt = expectedAclCreatedAt;
+
+        final var expectedStorageKey = UUID.randomUUID().toString();
+
         when(memberGateway.findById(ownerId))
                 .thenReturn(Optional.of(owner));
 
         when(fileGateway.findByFolder(any()))
                 .thenReturn(List.of());
 
-        when(folderGateway.findById(any()))
+        when(folderGateway.findByIdWithMemberAccess(any(), any()))
                 .thenReturn(Optional.of(folder));
 
         doNothing()
@@ -463,6 +553,18 @@ class DefaultCreateFileUseCaseTest {
         doThrow(new IllegalStateException("ContentGateway Exception"))
                 .when(storageService)
                 .delete(any());
+
+        when(aclGateway.findByResource(any()))
+                .thenReturn(Optional.of(Acl.with(
+                        expectedAclId,
+                        expectedAclResource,
+                        expectedAclDirectEntries,
+                        expectedAclInheritedEntries,
+                        expectedAclCreatedAt,
+                        expectedAclUpdatedAt)));
+
+        when(storageKeyGenerator.generate())
+                .thenReturn(expectedStorageKey);
 
         final var input = CreateFileInput.of(
                 ownerId.getValue(),
@@ -477,8 +579,8 @@ class DefaultCreateFileUseCaseTest {
         assertEquals(expectedExceptionMessage, actualException.getMessage());
         assertEquals("ContentGateway Exception", actualException.getCause().getMessage());
 
-        verify(folderGateway, times(1)).findById(any());
-        verify(folderGateway, times(1)).findById(eq(expectedFolderId));
+        verify(folderGateway, times(1)).findByIdWithMemberAccess(any(), any());
+        verify(folderGateway, times(1)).findByIdWithMemberAccess(eq(expectedFolderId), eq(ownerId));
         verify(storageService, times(1)).store(any(), any());
         verify(storageService, times(1)).store(any(), eq(expectedContent));
         verify(storageService, times(1)).delete(any());
@@ -530,15 +632,37 @@ class DefaultCreateFileUseCaseTest {
 
         final var expectedExceptionMessage = "Could not store BinaryContent";
 
+        final var expectedAclId = AclID.unique();
+        final var expectedAclResource = Resource.folder(expectedFolderId);
+        final var expectedAclDirectEntries = Set.of(Entry.create(ownerId, AccessPermission.mostPrivileged(),
+                SharePermission.mostPrivileged()));
+        final var expectedAclInheritedEntries = Set.<Entry>of();
+        final var expectedAclCreatedAt = Instant.now();
+        final var expectedAclUpdatedAt = expectedAclCreatedAt;
+
+        final var expectedStorageKey = UUID.randomUUID().toString();
+
         when(memberGateway.findById(ownerId))
                 .thenReturn(Optional.of(owner));
 
-        when(folderGateway.findById(any()))
+        when(folderGateway.findByIdWithMemberAccess(any(), any()))
                 .thenReturn(Optional.of(folder));
 
         doThrow(new IllegalStateException("ContentGateway Exception"))
                 .when(storageService)
                 .store(any(), any());
+
+        when(aclGateway.findByResource(any()))
+                .thenReturn(Optional.of(Acl.with(
+                        expectedAclId,
+                        expectedAclResource,
+                        expectedAclDirectEntries,
+                        expectedAclInheritedEntries,
+                        expectedAclCreatedAt,
+                        expectedAclUpdatedAt)));
+
+        when(storageKeyGenerator.generate())
+                .thenReturn(expectedStorageKey);
 
         final var input = CreateFileInput.of(
                 ownerId.getValue(),
@@ -553,8 +677,8 @@ class DefaultCreateFileUseCaseTest {
         assertEquals(expectedExceptionMessage, actualException.getMessage());
         assertEquals("ContentGateway Exception", actualException.getCause().getMessage());
 
-        verify(folderGateway, times(1)).findById(any());
-        verify(folderGateway, times(1)).findById(eq(expectedFolderId));
+        verify(folderGateway, times(1)).findByIdWithMemberAccess(any(), any());
+        verify(folderGateway, times(1)).findByIdWithMemberAccess(eq(expectedFolderId), eq(ownerId));
         verify(storageService, times(1)).store(any(), any());
         verify(storageService, times(1)).store(any(), eq(expectedContent));
         verify(fileGateway, times(1)).findByFolder(any());
@@ -596,11 +720,28 @@ class DefaultCreateFileUseCaseTest {
         final var expectedErrorCount = 1;
         final var expectedErrorMessage = "'name' cannot be a reserved name: NUL";
 
+        final var expectedAclId = AclID.unique();
+        final var expectedAclResource = Resource.folder(expectedFolderId);
+        final var expectedAclDirectEntries = Set.of(Entry.create(ownerId, AccessPermission.mostPrivileged(),
+                SharePermission.mostPrivileged()));
+        final var expectedAclInheritedEntries = Set.<Entry>of();
+        final var expectedAclCreatedAt = Instant.now();
+        final var expectedAclUpdatedAt = expectedAclCreatedAt;
+
         when(memberGateway.findById(ownerId))
                 .thenReturn(Optional.of(owner));
 
-        when(folderGateway.findById(expectedFolderId))
+        when(folderGateway.findByIdWithMemberAccess(expectedFolderId, ownerId))
                 .thenReturn(Optional.of(folder));
+
+        when(aclGateway.findByResource(any()))
+                .thenReturn(Optional.of(Acl.with(
+                        expectedAclId,
+                        expectedAclResource,
+                        expectedAclDirectEntries,
+                        expectedAclInheritedEntries,
+                        expectedAclCreatedAt,
+                        expectedAclUpdatedAt)));
 
         final var input = CreateFileInput.of(
                 ownerId.getValue(),
@@ -616,8 +757,8 @@ class DefaultCreateFileUseCaseTest {
         assertEquals(expectedErrorCount, actualException.getErrors().size());
         assertEquals(expectedErrorMessage, actualException.getErrors().get(0).message());
 
-        verify(folderGateway, times(1)).findById(any());
-        verify(folderGateway, times(1)).findById(eq(expectedFolderId));
+        verify(folderGateway, times(1)).findByIdWithMemberAccess(any(), any());
+        verify(folderGateway, times(1)).findByIdWithMemberAccess(eq(expectedFolderId), eq(ownerId));
         verify(storageService, times(0)).store(any(), any());
         verify(fileGateway, times(0)).findByFolder(any());
         verify(storageService, times(0)).delete(any());
@@ -657,8 +798,28 @@ class DefaultCreateFileUseCaseTest {
         final var expectedErrorCount = 1;
         final var expectedErrorMessage = "You have exceeded your current quota of 1 BYTE";
 
+        final var expectedAclId = AclID.unique();
+        final var expectedAclResource = Resource.folder(expectedFolderId);
+        final var expectedAclDirectEntries = Set.of(Entry.create(ownerId, AccessPermission.mostPrivileged(),
+                SharePermission.mostPrivileged()));
+        final var expectedAclInheritedEntries = Set.<Entry>of();
+        final var expectedAclCreatedAt = Instant.now();
+        final var expectedAclUpdatedAt = expectedAclCreatedAt;
+
         when(memberGateway.findById(ownerId))
                 .thenReturn(Optional.of(owner));
+
+        when(folderGateway.findByIdWithMemberAccess(expectedFolderId, ownerId))
+                .thenReturn(Optional.of(folder));
+
+        when(aclGateway.findByResource(any()))
+                .thenReturn(Optional.of(Acl.with(
+                        expectedAclId,
+                        expectedAclResource,
+                        expectedAclDirectEntries,
+                        expectedAclInheritedEntries,
+                        expectedAclCreatedAt,
+                        expectedAclUpdatedAt)));
 
         final var input = CreateFileInput.of(
                 ownerId.getValue(),
@@ -674,7 +835,7 @@ class DefaultCreateFileUseCaseTest {
         assertEquals(expectedErrorCount, actualException.getErrors().size());
         assertEquals(expectedErrorMessage, actualException.getErrors().get(0).message());
 
-        verify(folderGateway, times(0)).findById(any());
+        verify(folderGateway, times(1)).findByIdWithMemberAccess(any(), any());
         verify(storageService, times(0)).store(any(), any());
         verify(fileGateway, times(0)).findByFolder(any());
         verify(storageService, times(0)).delete(any());
@@ -714,17 +875,42 @@ class DefaultCreateFileUseCaseTest {
         final var expectedErrorCount = 1;
         final var expectedErrorMessage = "'type' cannot be null.";
 
+        final var expectedAclId = AclID.unique();
+        final var expectedAclResource = Resource.folder(expectedFolderId);
+        final var expectedAclDirectEntries = Set.of(Entry.create(ownerId, AccessPermission.mostPrivileged(),
+                SharePermission.mostPrivileged()));
+        final var expectedAclInheritedEntries = Set.<Entry>of();
+        final var expectedAclCreatedAt = Instant.now();
+        final var expectedAclUpdatedAt = expectedAclCreatedAt;
+
+        final var expectedStorageKey = UUID.randomUUID().toString();
+
         when(memberGateway.findById(any()))
                 .thenReturn(Optional.of(owner));
 
         when(fileGateway.findByFolder(any()))
                 .thenReturn(List.of());
 
-        when(folderGateway.findById(any()))
+        when(folderGateway.findByIdWithMemberAccess(any(), any()))
+                .thenReturn(Optional.of(folder));
+
+        when(folderGateway.findByIdWithMemberAccess(expectedFolderId, ownerId))
                 .thenReturn(Optional.of(folder));
 
         doNothing()
                 .when(storageService).store(any(), any());
+
+        when(aclGateway.findByResource(any()))
+                .thenReturn(Optional.of(Acl.with(
+                        expectedAclId,
+                        expectedAclResource,
+                        expectedAclDirectEntries,
+                        expectedAclInheritedEntries,
+                        expectedAclCreatedAt,
+                        expectedAclUpdatedAt)));
+
+        when(storageKeyGenerator.generate())
+                .thenReturn(expectedStorageKey);
 
         final var input = CreateFileInput.of(
                 ownerId.getValue(),
@@ -740,8 +926,8 @@ class DefaultCreateFileUseCaseTest {
         assertEquals(expectedErrorCount, actualException.getErrors().size());
         assertEquals(expectedErrorMessage, actualException.getErrors().get(0).message());
 
-        verify(folderGateway, times(1)).findById(any());
-        verify(folderGateway, times(1)).findById(eq(expectedFolderId));
+        verify(folderGateway, times(1)).findByIdWithMemberAccess(any(), any());
+        verify(folderGateway, times(1)).findByIdWithMemberAccess(eq(expectedFolderId), eq(ownerId));
         verify(storageService, times(1)).store(any(), any());
         verify(storageService, times(1)).store(any(), eq(expectedContent));
         verify(storageService, times(0)).delete(any());

--- a/application/src/test/java/com/callv2/drive/application/file/delete/DefaultDeleteFileUseCaseTest.java
+++ b/application/src/test/java/com/callv2/drive/application/file/delete/DefaultDeleteFileUseCaseTest.java
@@ -88,6 +88,8 @@ public class DefaultDeleteFileUseCaseTest {
                 expectedFolderId,
                 expectedFileName,
                 expectedContent,
+                expectedCreatorId,
+                null,
                 expectedCreatedAt,
                 expectedUpdatedAt,
                 null,
@@ -96,7 +98,7 @@ public class DefaultDeleteFileUseCaseTest {
         when(memberGateway.findById(expectedDeleterId))
                 .thenReturn(Optional.of(deleter));
 
-        when(fileGateway.findById(expectedFileId))
+        when(fileGateway.findByIdWithMemberAccess(expectedFileId, deleter.getId()))
                 .thenReturn(Optional.of(file));
 
         when(fileGateway.update(any()))
@@ -110,8 +112,8 @@ public class DefaultDeleteFileUseCaseTest {
 
         verify(memberGateway, times(1)).findById(any());
         verify(memberGateway, times(1)).findById(eq(expectedDeleterId));
-        verify(fileGateway, times(1)).findById(any());
-        verify(fileGateway, times(1)).findById(eq(expectedFileId));
+        verify(fileGateway, times(1)).findByIdWithMemberAccess(any(), any());
+        verify(fileGateway, times(1)).findByIdWithMemberAccess(eq(expectedFileId), eq(deleter.getId()));
         verify(fileGateway, times(0)).deleteById(any());
         verify(eventDispatcher, times(1)).notify(any(File.class));
         verify(eventDispatcher, times(1)).notify(any(EventSource.class));
@@ -145,7 +147,7 @@ public class DefaultDeleteFileUseCaseTest {
 
         verify(memberGateway, times(1)).findById(any());
         verify(memberGateway, times(1)).findById(eq(expectedDeleterId));
-        verify(fileGateway, never()).findById(any());
+        verify(fileGateway, never()).findByIdWithMemberAccess(any(), any());
         verify(fileGateway, never()).deleteById(any());
         verify(eventDispatcher, never()).notify(any(EventSource.class));
     }
@@ -176,7 +178,7 @@ public class DefaultDeleteFileUseCaseTest {
         when(memberGateway.findById(expectedDeleterId))
                 .thenReturn(Optional.of(deleter));
 
-        when(fileGateway.findById(expectedFileId))
+        when(fileGateway.findByIdWithMemberAccess(expectedFileId, deleter.getId()))
                 .thenReturn(Optional.empty());
 
         final var input = DeleteFileInput.of(
@@ -191,8 +193,8 @@ public class DefaultDeleteFileUseCaseTest {
 
         verify(memberGateway, times(1)).findById(any());
         verify(memberGateway, times(1)).findById(eq(expectedDeleterId));
-        verify(fileGateway, times(1)).findById(any());
-        verify(fileGateway, times(1)).findById(eq(expectedFileId));
+        verify(fileGateway, times(1)).findByIdWithMemberAccess(any(), any());
+        verify(fileGateway, times(1)).findByIdWithMemberAccess(eq(expectedFileId), eq(deleter.getId()));
         verify(fileGateway, never()).deleteById(any());
         verify(eventDispatcher, never()).notify(any(EventSource.class));
 
@@ -236,7 +238,7 @@ public class DefaultDeleteFileUseCaseTest {
 
         verify(memberGateway, times(1)).findById(any());
         verify(memberGateway, times(1)).findById(eq(expectedDeleterId));
-        verify(fileGateway, never()).findById(any());
+        verify(fileGateway, never()).findByIdWithMemberAccess(any(), any());
         verify(fileGateway, never()).deleteById(any());
         verify(eventDispatcher, never()).notify(any(EventSource.class));
 

--- a/application/src/test/java/com/callv2/drive/application/file/delete/DefaultDeleteFileUseCaseTest.java
+++ b/application/src/test/java/com/callv2/drive/application/file/delete/DefaultDeleteFileUseCaseTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.when;
 
 import java.time.Instant;
 import java.util.Optional;
+import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -56,7 +57,7 @@ public class DefaultDeleteFileUseCaseTest {
     void givenAValidParam_whenCallsExecute_thenShouldDeleteFile() {
 
         final var deleter = Member.with(
-                MemberID.of("deleter"),
+                MemberID.of(UUID.randomUUID()),
                 Username.of("username"),
                 Nickname.of("nickname"),
                 Quota.of(0, QuotaUnit.BYTE),
@@ -69,6 +70,7 @@ public class DefaultDeleteFileUseCaseTest {
                 .approveQuotaRequest();
 
         final FileID expectedFileId = FileID.unique();
+        final MemberID expectedCreatorId = deleter.getId();
         final MemberID expectedDeleterId = deleter.getId();
         final FolderID expectedFolderId = FolderID.unique();
         final FileName expectedFileName = FileName.of("file.txt");
@@ -81,6 +83,7 @@ public class DefaultDeleteFileUseCaseTest {
         final Instant expectedUpdatedAt = Instant.now();
         final var file = File.with(
                 expectedFileId,
+                expectedCreatorId,
                 expectedDeleterId,
                 expectedFolderId,
                 expectedFileName,
@@ -117,7 +120,7 @@ public class DefaultDeleteFileUseCaseTest {
     @Test
     void givenAInvalidMemberId_whenCallsExecute_thenShouldThrowNotFoundException() {
 
-        final MemberID expectedDeleterId = MemberID.of("deleter");
+        final MemberID expectedDeleterId = MemberID.of(UUID.randomUUID());
         final FileID expectedFileId = FileID.unique();
 
         final String expectedExceptionMessage = "[Member] not found.";
@@ -150,7 +153,7 @@ public class DefaultDeleteFileUseCaseTest {
     @Test
     void givenAInvalidFileId_whenCallsExecute_thenShouldThrowNotFoundException() {
 
-        final MemberID expectedDeleterId = MemberID.of("deleter");
+        final MemberID expectedDeleterId = MemberID.of(UUID.randomUUID());
         final FileID expectedFileId = FileID.unique();
 
         final String expectedExceptionMessage = "[File] not found.";
@@ -158,7 +161,7 @@ public class DefaultDeleteFileUseCaseTest {
         final var expectedErrorMessage = "[File] with id [%s] not found.".formatted(expectedFileId.getValue());
 
         final var deleter = Member.with(
-                MemberID.of("owner"),
+                MemberID.of(UUID.randomUUID()),
                 Username.of("username"),
                 Nickname.of("nickname"),
                 Quota.of(0, QuotaUnit.BYTE),
@@ -198,7 +201,7 @@ public class DefaultDeleteFileUseCaseTest {
     @Test
     void givenAValidMemberIdButNotHaveSystemAccess_whenCallsExecute_thenShouldThrowNotFoundException() {
 
-        final MemberID expectedDeleterId = MemberID.of("deleter");
+        final MemberID expectedDeleterId = MemberID.of(UUID.randomUUID());
         final FileID expectedFileId = FileID.unique();
 
         final String expectedExceptionMessage = "The requested action is not allowed.";
@@ -206,7 +209,7 @@ public class DefaultDeleteFileUseCaseTest {
         final var expectedErrorMessage = "Member does not have permission to delete files.";
 
         final var deleter = Member.with(
-                MemberID.of("owner"),
+                MemberID.of(UUID.randomUUID()),
                 Username.of("username"),
                 Nickname.of("nickname"),
                 Quota.of(0, QuotaUnit.BYTE),

--- a/application/src/test/java/com/callv2/drive/application/file/delete/DefaultDeleteFileUseCaseTest.java
+++ b/application/src/test/java/com/callv2/drive/application/file/delete/DefaultDeleteFileUseCaseTest.java
@@ -127,7 +127,8 @@ public class DefaultDeleteFileUseCaseTest {
 
         final String expectedExceptionMessage = "[Member] not found.";
         final var expectedErrorCount = 1;
-        final var expectedErrorMessage = "[Member] with id [%s] not found.".formatted(expectedDeleterId.getValue());
+        final var expectedErrorMessage = "[Member] with id [%s] not found."
+                .formatted(expectedDeleterId.getValue());
 
         when(memberGateway.findById(any()))
                 .thenReturn(Optional.empty());
@@ -155,7 +156,6 @@ public class DefaultDeleteFileUseCaseTest {
     @Test
     void givenAInvalidFileId_whenCallsExecute_thenShouldThrowNotFoundException() {
 
-        final MemberID expectedDeleterId = MemberID.of(UUID.randomUUID());
         final FileID expectedFileId = FileID.unique();
 
         final String expectedExceptionMessage = "[File] not found.";
@@ -174,6 +174,8 @@ public class DefaultDeleteFileUseCaseTest {
                 0L)
                 .requestQuota(Quota.of(1, QuotaUnit.GIGABYTE))
                 .approveQuotaRequest();
+
+        final MemberID expectedDeleterId = deleter.getId();
 
         when(memberGateway.findById(expectedDeleterId))
                 .thenReturn(Optional.of(deleter));

--- a/application/src/test/java/com/callv2/drive/application/file/retrieve/get/DefaultGetFileUseCaseTest.java
+++ b/application/src/test/java/com/callv2/drive/application/file/retrieve/get/DefaultGetFileUseCaseTest.java
@@ -61,10 +61,10 @@ public class DefaultGetFileUseCaseTest {
 
         final var expectedId = expectedFile.getId();
 
-        when(fileGateway.findById(any()))
+        when(fileGateway.findByIdWithMemberAccess(any(), any()))
                 .thenReturn(Optional.of(File.with(expectedFile)));
 
-        final var aCommand = GetFileInput.from(expectedId.getValue());
+        final var aCommand = GetFileInput.from(expectedId.getValue(), creatorId.getValue());
 
         final var actualOuput = assertDoesNotThrow(() -> useCase.execute(aCommand));
 
@@ -73,8 +73,8 @@ public class DefaultGetFileUseCaseTest {
         assertEquals(expectedFile.getCreatedAt(), actualOuput.createdAt());
         assertEquals(expectedFile.getUpdatedAt(), actualOuput.updatedAt());
 
-        verify(fileGateway, times(1)).findById(any());
-        verify(fileGateway, times(1)).findById(eq(expectedId));
+        verify(fileGateway, times(1)).findByIdWithMemberAccess(any(), any());
+        verify(fileGateway, times(1)).findByIdWithMemberAccess(eq(expectedId), eq(creatorId));
     }
 
     @Test
@@ -82,14 +82,16 @@ public class DefaultGetFileUseCaseTest {
 
         final var expectedId = FileID.unique();
 
+        final var actorId = MemberID.of(UUID.randomUUID());
+
         final var expectedExceptionMessage = "[File] not found.";
         final var expectedErrorsCount = 1;
         final var expectedErrorMessage = "[File] with id [%s] not found.".formatted(expectedId.getValue().toString());
 
-        when(fileGateway.findById(any()))
+        when(fileGateway.findByIdWithMemberAccess(any(), any()))
                 .thenReturn(Optional.empty());
 
-        final var aCommand = GetFileInput.from(expectedId.getValue());
+        final var aCommand = GetFileInput.from(expectedId.getValue(), actorId.getValue());
 
         final var actualException = assertThrows(NotFoundException.class, () -> useCase.execute(aCommand));
 
@@ -97,8 +99,8 @@ public class DefaultGetFileUseCaseTest {
         assertEquals(expectedErrorsCount, actualException.getErrors().size());
         assertEquals(expectedErrorMessage, actualException.getErrors().get(0).message());
 
-        verify(fileGateway, times(1)).findById(any());
-        verify(fileGateway, times(1)).findById(eq(expectedId));
+        verify(fileGateway, times(1)).findByIdWithMemberAccess(any(), any());
+        verify(fileGateway, times(1)).findByIdWithMemberAccess(eq(expectedId), eq(actorId));
     }
 
 }

--- a/application/src/test/java/com/callv2/drive/application/file/retrieve/get/DefaultGetFileUseCaseTest.java
+++ b/application/src/test/java/com/callv2/drive/application/file/retrieve/get/DefaultGetFileUseCaseTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Optional;
+import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -38,7 +39,8 @@ public class DefaultGetFileUseCaseTest {
     @Test
     void givenAValidId_whenCallsExecute_thenShouldReturnFile() {
 
-        final var ownerId = MemberID.of("owner");
+        final var creatorId = MemberID.of(UUID.randomUUID());
+        final var ownerId = creatorId;
 
         final var expectedFolder = Folder.createRoot(ownerId);
 
@@ -50,7 +52,11 @@ public class DefaultGetFileUseCaseTest {
 
         final var expectedContent = Content.of(expectedContentLocation, expectedContentType, expectedContentSize);
 
-        final var expectedFile = File.create(ownerId, expectedFolder.getId(), FileName.of(expectedName),
+        final var expectedFile = File.create(
+                creatorId,
+                ownerId,
+                expectedFolder.getId(),
+                FileName.of(expectedName),
                 expectedContent);
 
         final var expectedId = expectedFile.getId();

--- a/application/src/test/java/com/callv2/drive/application/folder/move/DefaultMoveFolderUseCaseTest.java
+++ b/application/src/test/java/com/callv2/drive/application/folder/move/DefaultMoveFolderUseCaseTest.java
@@ -19,6 +19,9 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.callv2.drive.domain.access.Acl;
+import com.callv2.drive.domain.access.AclGateway;
+import com.callv2.drive.domain.access.Resource;
 import com.callv2.drive.domain.folder.Folder;
 import com.callv2.drive.domain.folder.FolderGateway;
 import com.callv2.drive.domain.folder.FolderName;
@@ -31,10 +34,13 @@ public class DefaultMoveFolderUseCaseTest {
     DefaultMoveFolderUseCase useCase;
 
     @Mock
+    AclGateway aclGateway;
+
+    @Mock
     FolderGateway folderGateway;
 
     @Test
-    void givenVAlidInput_whenCallsExecute_thenMoveFolder() {
+    void givenValidInput_whenCallsExecute_thenMoveFolder() {
 
         final var ownerId = MemberID.of(UUID.randomUUID());
         final var actorId = ownerId;
@@ -43,6 +49,21 @@ public class DefaultMoveFolderUseCaseTest {
 
         final var expectedFolderToMove = Folder.create(ownerId, ownerId, FolderName.of("folder1"), expectedRootFolder);
         final var expectedFolderTarget = Folder.create(ownerId, ownerId, FolderName.of("folder2"), expectedRootFolder);
+
+        final var expectedFolderToMoveResource = Resource.folder(expectedFolderToMove.getId());
+        final var expectedFolderTargetResource = Resource.folder(expectedFolderTarget.getId());
+
+        final var expectedFolderToMoveAcl = Acl.create(expectedFolderToMoveResource);
+        final var expectedFolderTargetAcl = Acl.create(expectedFolderTargetResource);
+
+        expectedFolderToMoveAcl.grantTotal(actorId);
+        expectedFolderTargetAcl.grantTotal(actorId);
+
+        when(aclGateway.findByResource(expectedFolderToMoveResource))
+                .thenReturn(Optional.of(expectedFolderToMoveAcl));
+
+        when(aclGateway.findByResource(expectedFolderTargetResource))
+                .thenReturn(Optional.of(expectedFolderTargetAcl));
 
         when(folderGateway.findByIdWithMemberAccess(expectedFolderToMove.getId(), ownerId))
                 .thenReturn(Optional.of(expectedFolderToMove));

--- a/application/src/test/java/com/callv2/drive/application/folder/move/DefaultMoveFolderUseCaseTest.java
+++ b/application/src/test/java/com/callv2/drive/application/folder/move/DefaultMoveFolderUseCaseTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -35,7 +36,7 @@ public class DefaultMoveFolderUseCaseTest {
     @Test
     void givenVAlidInput_whenCallsExecute_thenMoveFolder() {
 
-        final var ownerId = MemberID.of("owner");
+        final var ownerId = MemberID.of(UUID.randomUUID());
 
         final var expectedRootFolder = Folder.createRoot(ownerId);
 

--- a/application/src/test/java/com/callv2/drive/application/folder/move/DefaultMoveFolderUseCaseTest.java
+++ b/application/src/test/java/com/callv2/drive/application/folder/move/DefaultMoveFolderUseCaseTest.java
@@ -53,7 +53,7 @@ public class DefaultMoveFolderUseCaseTest {
         when(folderGateway.findByIdWithMemberAccess(expectedRootFolder.getId(), ownerId))
                 .thenReturn(Optional.of(expectedRootFolder));
 
-        when(folderGateway.findByParentFolderId(expectedFolderTarget.getId()))
+        when(folderGateway.findByParentFolderIdWithMemberAccess(expectedFolderTarget.getId(), actorId))
                 .thenReturn(Set.of());
 
         final var input = new MoveFolderInput(
@@ -65,7 +65,7 @@ public class DefaultMoveFolderUseCaseTest {
 
         verify(folderGateway, never()).updateAll(anyList());
         verify(folderGateway, times(1)).update(eq(expectedFolderToMove));
-        verify(folderGateway, times(1)).findByParentFolderId(any());
+        verify(folderGateway, times(1)).findByParentFolderIdWithMemberAccess(any(), any());
 
     }
 

--- a/application/src/test/java/com/callv2/drive/application/folder/move/DefaultMoveFolderUseCaseTest.java
+++ b/application/src/test/java/com/callv2/drive/application/folder/move/DefaultMoveFolderUseCaseTest.java
@@ -37,19 +37,20 @@ public class DefaultMoveFolderUseCaseTest {
     void givenVAlidInput_whenCallsExecute_thenMoveFolder() {
 
         final var ownerId = MemberID.of(UUID.randomUUID());
+        final var actorId = ownerId;
 
         final var expectedRootFolder = Folder.createRoot(ownerId);
 
-        final var expectedFolderToMove = Folder.create(ownerId, FolderName.of("folder1"), expectedRootFolder);
-        final var expectedFolderTarget = Folder.create(ownerId, FolderName.of("folder2"), expectedRootFolder);
+        final var expectedFolderToMove = Folder.create(ownerId, ownerId, FolderName.of("folder1"), expectedRootFolder);
+        final var expectedFolderTarget = Folder.create(ownerId, ownerId, FolderName.of("folder2"), expectedRootFolder);
 
-        when(folderGateway.findById(expectedFolderToMove.getId()))
+        when(folderGateway.findByIdWithMemberAccess(expectedFolderToMove.getId(), ownerId))
                 .thenReturn(Optional.of(expectedFolderToMove));
 
-        when(folderGateway.findById(expectedFolderTarget.getId()))
+        when(folderGateway.findByIdWithMemberAccess(expectedFolderTarget.getId(), ownerId))
                 .thenReturn(Optional.of(expectedFolderTarget));
 
-        when(folderGateway.findById(expectedRootFolder.getId()))
+        when(folderGateway.findByIdWithMemberAccess(expectedRootFolder.getId(), ownerId))
                 .thenReturn(Optional.of(expectedRootFolder));
 
         when(folderGateway.findByParentFolderId(expectedFolderTarget.getId()))
@@ -57,7 +58,8 @@ public class DefaultMoveFolderUseCaseTest {
 
         final var input = new MoveFolderInput(
                 expectedFolderToMove.getId().getValue(),
-                expectedFolderTarget.getId().getValue());
+                expectedFolderTarget.getId().getValue(),
+                actorId.getValue());
 
         assertDoesNotThrow(() -> useCase.execute(input));
 

--- a/application/src/test/java/com/callv2/drive/application/folder/retrieve/get/DefaultGetFolderUseCaseTest.java
+++ b/application/src/test/java/com/callv2/drive/application/folder/retrieve/get/DefaultGetFolderUseCaseTest.java
@@ -43,6 +43,7 @@ public class DefaultGetFolderUseCaseTest {
     void givenAValidFolderId_whenCallsExecute_thenShouldReturnFolder() {
 
         final var ownerId = MemberID.of(UUID.randomUUID());
+        final var actorId = ownerId;
 
         final var expectedFolderName = "folder";
         final var expectedFolder = Folder.create(
@@ -72,7 +73,7 @@ public class DefaultGetFolderUseCaseTest {
         when(folderGateway.findByIdWithMemberAccess(expectedFolderId, ownerId))
                 .thenReturn(Optional.of(expectedFolder));
 
-        when(folderGateway.findByParentFolderId(expectedFolder.getId()))
+        when(folderGateway.findByParentFolderIdWithMemberAccess(expectedFolder.getId(), actorId))
                 .thenReturn(expectedSubFolders);
 
         final var input = GetFolderInput.with(expectedFolderId.getValue(), ownerId.getValue());
@@ -90,8 +91,8 @@ public class DefaultGetFolderUseCaseTest {
         verify(folderGateway, times(1)).findByIdWithMemberAccess(any(), any());
         verify(folderGateway, times(1)).findByIdWithMemberAccess(eq(expectedFolderId), eq(ownerId));
 
-        verify(folderGateway, times(1)).findByParentFolderId(any());
-        verify(folderGateway, times(1)).findByParentFolderId(eq(expectedFolder.getId()));
+        verify(folderGateway, times(1)).findByParentFolderIdWithMemberAccess(any(), any());
+        verify(folderGateway, times(1)).findByParentFolderIdWithMemberAccess(eq(expectedFolder.getId()), eq(actorId));
 
     }
 

--- a/application/src/test/java/com/callv2/drive/application/folder/retrieve/get/DefaultGetFolderUseCaseTest.java
+++ b/application/src/test/java/com/callv2/drive/application/folder/retrieve/get/DefaultGetFolderUseCaseTest.java
@@ -30,92 +30,96 @@ import com.callv2.drive.domain.member.MemberID;
 @ExtendWith(MockitoExtension.class)
 public class DefaultGetFolderUseCaseTest {
 
-        @InjectMocks
-        DefaultGetFolderUseCase useCase;
+    @InjectMocks
+    DefaultGetFolderUseCase useCase;
 
-        @Mock
-        FolderGateway folderGateway;
+    @Mock
+    FolderGateway folderGateway;
 
-        @Mock
-        FileGateway fileGateway;
+    @Mock
+    FileGateway fileGateway;
 
-        @Test
-        void givenAValidFolderId_whenCallsExecute_thenShouldReturnFolder() {
+    @Test
+    void givenAValidFolderId_whenCallsExecute_thenShouldReturnFolder() {
 
-                final var ownerId = MemberID.of(UUID.randomUUID());
+        final var ownerId = MemberID.of(UUID.randomUUID());
 
-                final var expectedFolderName = "folder";
-                final var expectedFolder = Folder.create(
-                                ownerId,
-                                FolderName.of(expectedFolderName),
-                                Folder.createRoot(ownerId));
+        final var expectedFolderName = "folder";
+        final var expectedFolder = Folder.create(
+                ownerId,
+                ownerId,
+                FolderName.of(expectedFolderName),
+                Folder.createRoot(ownerId));
 
-                final var expectedSubFolder1 = Folder.create(
-                                ownerId,
-                                FolderName.of("subFolder1"),
-                                expectedFolder);
-                final var expectedSubFolder2 = Folder.create(
-                                ownerId,
-                                FolderName.of("subFolder2"),
-                                expectedFolder);
+        final var expectedSubFolder1 = Folder.create(
+                ownerId,
+                ownerId,
+                FolderName.of("subFolder1"),
+                expectedFolder);
+        final var expectedSubFolder2 = Folder.create(
+                ownerId,
+                ownerId,
+                FolderName.of("subFolder2"),
+                expectedFolder);
 
-                final var expectedSubFolders = Set.of(expectedSubFolder1, expectedSubFolder2);
+        final var expectedSubFolders = Set.of(expectedSubFolder1, expectedSubFolder2);
 
-                final var expectedFolderId = expectedFolder.getId();
-                final var expectedCreatedAt = expectedFolder.getCreatedAt();
-                final var expectedUpdatedAt = expectedFolder.getUpdatedAt();
-                final var expectedDeletedAt = expectedFolder.getDeletedAt();
+        final var expectedFolderId = expectedFolder.getId();
+        final var expectedCreatedAt = expectedFolder.getCreatedAt();
+        final var expectedUpdatedAt = expectedFolder.getUpdatedAt();
+        final var expectedDeletedAt = expectedFolder.getDeletedAt();
 
-                when(folderGateway.findById(expectedFolderId))
-                                .thenReturn(Optional.of(expectedFolder));
+        when(folderGateway.findByIdWithMemberAccess(expectedFolderId, ownerId))
+                .thenReturn(Optional.of(expectedFolder));
 
-                when(folderGateway.findByParentFolderId(expectedFolder.getId()))
-                                .thenReturn(expectedSubFolders);
+        when(folderGateway.findByParentFolderId(expectedFolder.getId()))
+                .thenReturn(expectedSubFolders);
 
-                final var input = GetFolderInput.with(expectedFolderId.getValue());
+        final var input = GetFolderInput.with(expectedFolderId.getValue(), ownerId.getValue());
 
-                final var actualOutput = assertDoesNotThrow(() -> useCase.execute(input));
+        final var actualOutput = assertDoesNotThrow(() -> useCase.execute(input));
 
-                assertEquals(expectedFolderId.getValue(), actualOutput.id());
-                assertEquals(expectedFolderName, actualOutput.name());
-                assertEquals(expectedFolder.getParentFolder().getValue(), actualOutput.parentFolder());
-                assertEquals(expectedSubFolders.size(), actualOutput.subFolders().size());
-                assertEquals(expectedCreatedAt, actualOutput.createdAt());
-                assertEquals(expectedUpdatedAt, actualOutput.updatedAt());
-                assertEquals(expectedDeletedAt, actualOutput.deletedAt());
+        assertEquals(expectedFolderId.getValue(), actualOutput.id());
+        assertEquals(expectedFolderName, actualOutput.name());
+        assertEquals(expectedFolder.getParentFolder().getValue(), actualOutput.parentFolder());
+        assertEquals(expectedSubFolders.size(), actualOutput.subFolders().size());
+        assertEquals(expectedCreatedAt, actualOutput.createdAt());
+        assertEquals(expectedUpdatedAt, actualOutput.updatedAt());
+        assertEquals(expectedDeletedAt, actualOutput.deletedAt());
 
-                verify(folderGateway, times(1)).findById(any());
-                verify(folderGateway, times(1)).findById(eq(expectedFolderId));
+        verify(folderGateway, times(1)).findByIdWithMemberAccess(any(), any());
+        verify(folderGateway, times(1)).findByIdWithMemberAccess(eq(expectedFolderId), eq(ownerId));
 
-                verify(folderGateway, times(1)).findByParentFolderId(any());
-                verify(folderGateway, times(1)).findByParentFolderId(eq(expectedFolder.getId()));
+        verify(folderGateway, times(1)).findByParentFolderId(any());
+        verify(folderGateway, times(1)).findByParentFolderId(eq(expectedFolder.getId()));
 
-        }
+    }
 
-        @Test
-        void givenNotExistentFolderId_whenCallsExecute_thenShouldThorwsNotFoundException() {
+    @Test
+    void givenNotExistentFolderId_whenCallsExecute_thenShouldThorwsNotFoundException() {
 
-                final var expectedFolderId = FolderID.unique();
+        final var expectedFolderId = FolderID.unique();
+        final var expectActorId = MemberID.of(UUID.randomUUID());
 
-                final var expectedExceptionMessage = "[Folder] not found.";
-                final var expectedErrorCount = 1;
-                final var expectedErrorMessage = "[Folder] with id [%s] not found."
-                                .formatted(expectedFolderId.getValue());
+        final var expectedExceptionMessage = "[Folder] not found.";
+        final var expectedErrorCount = 1;
+        final var expectedErrorMessage = "[Folder] with id [%s] not found."
+                .formatted(expectedFolderId.getValue());
 
-                when(folderGateway.findById(expectedFolderId))
-                                .thenReturn(Optional.empty());
+        when(folderGateway.findByIdWithMemberAccess(expectedFolderId, expectActorId))
+                .thenReturn(Optional.empty());
 
-                final var input = GetFolderInput.with(expectedFolderId.getValue());
+        final var input = GetFolderInput.with(expectedFolderId.getValue(), UUID.randomUUID());
 
-                final var actualException = assertThrows(NotFoundException.class, () -> useCase.execute(input));
+        final var actualException = assertThrows(NotFoundException.class, () -> useCase.execute(input));
 
-                assertEquals(expectedExceptionMessage, actualException.getMessage());
-                assertEquals(expectedErrorCount, actualException.getErrors().size());
-                assertEquals(expectedErrorMessage, actualException.getErrors().get(0).message());
+        assertEquals(expectedExceptionMessage, actualException.getMessage());
+        assertEquals(expectedErrorCount, actualException.getErrors().size());
+        assertEquals(expectedErrorMessage, actualException.getErrors().get(0).message());
 
-                verify(folderGateway, times(1)).findById(any());
-                verify(folderGateway, times(1)).findById(eq(expectedFolderId));
+        verify(folderGateway, times(1)).findByIdWithMemberAccess(any(), any());
+        verify(folderGateway, times(1)).findByIdWithMemberAccess(eq(expectedFolderId), eq(expectActorId));
 
-        }
+    }
 
 }

--- a/application/src/test/java/com/callv2/drive/application/folder/retrieve/get/DefaultGetFolderUseCaseTest.java
+++ b/application/src/test/java/com/callv2/drive/application/folder/retrieve/get/DefaultGetFolderUseCaseTest.java
@@ -110,7 +110,7 @@ public class DefaultGetFolderUseCaseTest {
         when(folderGateway.findByIdWithMemberAccess(expectedFolderId, expectActorId))
                 .thenReturn(Optional.empty());
 
-        final var input = GetFolderInput.with(expectedFolderId.getValue(), UUID.randomUUID());
+        final var input = GetFolderInput.with(expectedFolderId.getValue(), expectActorId.getValue());
 
         final var actualException = assertThrows(NotFoundException.class, () -> useCase.execute(input));
 

--- a/application/src/test/java/com/callv2/drive/application/folder/retrieve/get/DefaultGetFolderUseCaseTest.java
+++ b/application/src/test/java/com/callv2/drive/application/folder/retrieve/get/DefaultGetFolderUseCaseTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -41,7 +42,7 @@ public class DefaultGetFolderUseCaseTest {
         @Test
         void givenAValidFolderId_whenCallsExecute_thenShouldReturnFolder() {
 
-                final var ownerId = MemberID.of("owner");
+                final var ownerId = MemberID.of(UUID.randomUUID());
 
                 final var expectedFolderName = "folder";
                 final var expectedFolder = Folder.create(

--- a/application/src/test/java/com/callv2/drive/application/member/synchronize/DefaultSynchronizeMemberUseCaseTest.java
+++ b/application/src/test/java/com/callv2/drive/application/member/synchronize/DefaultSynchronizeMemberUseCaseTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Optional;
+import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -38,7 +39,7 @@ public class DefaultSynchronizeMemberUseCaseTest {
     @Test
     void givenAnValidInput_whenCallsExecute_thenShouldSynchonizeMember() {
 
-        final var expectedIdVAlue = "123";
+        final var expectedIdVAlue = UUID.randomUUID();
         final var expectedUsernameValue = "username";
         final var expectedNicknameValue = "nickname";
         final var expectedCreatedAt = java.time.Instant.now();
@@ -101,7 +102,7 @@ public class DefaultSynchronizeMemberUseCaseTest {
     @Test
     void givenAnValidInputWhitNonExistentMember_whenCallsExecute_thenShouldCreateMember() {
 
-        final var expectedIdVAlue = "123";
+        final var expectedIdVAlue = UUID.randomUUID();
         final var expectedUsernameValue = "username";
         final var expectedNicknameValue = "nickname";
         final var expectedCreatedAt = java.time.Instant.now();

--- a/domain/src/main/java/com/callv2/drive/domain/Identifier.java
+++ b/domain/src/main/java/com/callv2/drive/domain/Identifier.java
@@ -15,6 +15,8 @@ public abstract class Identifier<T> implements ValueObject {
 
     public abstract String getStringValue();
 
+    public abstract Identifier<T> fromStringValue(String value);
+
     public T getValue() {
         return id;
     }

--- a/domain/src/main/java/com/callv2/drive/domain/Identifier.java
+++ b/domain/src/main/java/com/callv2/drive/domain/Identifier.java
@@ -15,8 +15,6 @@ public abstract class Identifier<T> implements ValueObject {
 
     public abstract String getStringValue();
 
-    public abstract Identifier<T> fromStringValue(String value);
-
     public T getValue() {
         return id;
     }

--- a/domain/src/main/java/com/callv2/drive/domain/access/AccessPermission.java
+++ b/domain/src/main/java/com/callv2/drive/domain/access/AccessPermission.java
@@ -1,0 +1,17 @@
+package com.callv2.drive.domain.access;
+
+public enum AccessPermission {
+    WRITE(0),
+    READ(1);
+
+    private final Integer level;
+
+    AccessPermission(int level) {
+        this.level = level;
+    }
+
+    public Integer getLevel() {
+        return level;
+    }
+
+}

--- a/domain/src/main/java/com/callv2/drive/domain/access/AccessPermission.java
+++ b/domain/src/main/java/com/callv2/drive/domain/access/AccessPermission.java
@@ -14,4 +14,12 @@ public enum AccessPermission {
         return level;
     }
 
+    public Boolean canWrite() {
+        return this.level <= WRITE.level;
+    }
+
+    public Boolean canRead() {
+        return this.level <= READ.level;
+    }
+
 }

--- a/domain/src/main/java/com/callv2/drive/domain/access/AccessPermission.java
+++ b/domain/src/main/java/com/callv2/drive/domain/access/AccessPermission.java
@@ -22,4 +22,8 @@ public enum AccessPermission {
         return this.level <= READ.level;
     }
 
+    public static AccessPermission mostPrivileged() {
+        return WRITE;
+    }
+
 }

--- a/domain/src/main/java/com/callv2/drive/domain/access/Acl.java
+++ b/domain/src/main/java/com/callv2/drive/domain/access/Acl.java
@@ -1,0 +1,111 @@
+package com.callv2.drive.domain.access;
+
+import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
+
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import com.callv2.drive.domain.AggregateRoot;
+import com.callv2.drive.domain.member.MemberID;
+import com.callv2.drive.domain.validation.ValidationError;
+import com.callv2.drive.domain.validation.ValidationHandler;
+
+public class Acl extends AggregateRoot<AclID> {
+
+    private final Resource<?> resource;
+    private Set<Entry> directEntries;
+    private Set<Entry> inheritedEntries;
+
+    private final Instant createdAt;
+    private Instant updatedAt;
+
+    public Acl(
+            final AclID id,
+            final Resource<?> resource,
+            final Set<Entry> directEntries,
+            final Set<Entry> inheritedEntries,
+            final Instant createdAt,
+            final Instant updatedAt) {
+        super(id);
+        this.resource = resource;
+        this.directEntries = nonNull(directEntries) ? new HashSet<>(directEntries) : new HashSet<>();
+        this.inheritedEntries = nonNull(inheritedEntries) ? new HashSet<>(inheritedEntries) : new HashSet<>();
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    @Override
+    public void validate(final ValidationHandler handler) {
+
+        if (isNull(resource))
+            handler.append(ValidationError.with("'resource' cannot be null"));
+
+        if (nonNull(resource))
+            resource.validate(handler);
+
+    }
+
+    public static Acl with(
+            final AclID id,
+            final Resource<?> resource,
+            final Set<Entry> entries,
+            final Set<Entry> inheritedEntries,
+            final Instant createdAt,
+            final Instant updatedAt) {
+        return new Acl(id, resource, entries, inheritedEntries, createdAt, updatedAt);
+    }
+
+    public static Acl create(final Resource<?> resource) {
+        Instant now = Instant.now();
+        return new Acl(
+                AclID.unique(),
+                resource,
+                null,
+                null,
+                now,
+                now);
+    }
+
+    public Optional<AccessPermission> effectiveAccessPermission(final MemberID member) {
+
+        return Stream.concat(directEntries.stream(), inheritedEntries.stream())
+                .filter(entry -> entry.member().equals(member))
+                .map(Entry::accessPermission)
+                .min((e1, e2) -> e1.getLevel().compareTo(e2.getLevel()));
+
+    }
+
+    public Optional<SharePermission> effectiveSharePermission(final MemberID member) {
+
+        return Stream.concat(directEntries.stream(), inheritedEntries.stream())
+                .filter(entry -> entry.member().equals(member))
+                .map(Entry::sharePermission)
+                .min((e1, e2) -> e1.getLevel().compareTo(e2.getLevel()));
+
+    }
+
+    public Resource<?> getResource() {
+        return resource;
+    }
+
+    public Set<Entry> getDirectEntries() {
+        return directEntries;
+    }
+
+    public Set<Entry> getInheritedEntries() {
+        return inheritedEntries;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+
+}

--- a/domain/src/main/java/com/callv2/drive/domain/access/Acl.java
+++ b/domain/src/main/java/com/callv2/drive/domain/access/Acl.java
@@ -101,6 +101,24 @@ public class Acl extends AggregateRoot<AclID> implements EventSource {
 
     }
 
+    public Acl inheritFrom(final Acl parentAcl) {
+        if (isNull(parentAcl))
+            throw new IllegalArgumentException("'parentAcl' should not be null");
+
+        final Instant now = Instant.now();
+
+        final Set<Entry> inheritedEntries = Stream
+                .concat(parentAcl.directEntries.stream(), parentAcl.inheritedEntries.stream())
+                .collect(Collectors.toSet());
+
+        this.inheritedEntries = inheritedEntries;
+        this.updatedAt = now;
+
+        this.events.add(AclUpdatedEvent.create(this));
+
+        return this;
+    }
+
     public Acl grantTotal(final MemberID member) {
         return this.grantEntry(member, AccessPermission.mostPrivileged(), SharePermission.mostPrivileged());
     }

--- a/domain/src/main/java/com/callv2/drive/domain/access/Acl.java
+++ b/domain/src/main/java/com/callv2/drive/domain/access/Acl.java
@@ -5,17 +5,23 @@ import static java.util.Objects.nonNull;
 
 import java.time.Instant;
 import java.util.HashSet;
+import java.util.LinkedList;
 import java.util.Optional;
+import java.util.Queue;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import com.callv2.drive.domain.AggregateRoot;
+import com.callv2.drive.domain.event.Event;
+import com.callv2.drive.domain.event.EventSource;
 import com.callv2.drive.domain.member.MemberID;
 import com.callv2.drive.domain.validation.ValidationError;
 import com.callv2.drive.domain.validation.ValidationHandler;
 
-public class Acl extends AggregateRoot<AclID> {
+public class Acl extends AggregateRoot<AclID> implements EventSource {
+
+    private Queue<Event<?>> events;
 
     private final Resource<?> resource;
     private Set<Entry> directEntries;
@@ -37,6 +43,8 @@ public class Acl extends AggregateRoot<AclID> {
         this.inheritedEntries = nonNull(inheritedEntries) ? new HashSet<>(inheritedEntries) : new HashSet<>();
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
+
+        this.events = new LinkedList<>();
     }
 
     @Override
@@ -50,14 +58,19 @@ public class Acl extends AggregateRoot<AclID> {
 
     }
 
+    @Override
+    public Optional<Event<?>> nextEvent() {
+        return Optional.ofNullable(this.events.poll());
+    }
+
     public static Acl with(
             final AclID id,
             final Resource<?> resource,
-            final Set<Entry> entries,
+            final Set<Entry> directEntries,
             final Set<Entry> inheritedEntries,
             final Instant createdAt,
             final Instant updatedAt) {
-        return new Acl(id, resource, entries, inheritedEntries, createdAt, updatedAt);
+        return new Acl(id, resource, directEntries, inheritedEntries, createdAt, updatedAt);
     }
 
     public static Acl create(final Resource<?> resource) {
@@ -112,6 +125,8 @@ public class Acl extends AggregateRoot<AclID> {
         this.directEntries.add(entry);
         this.updatedAt = Instant.now();
 
+        this.events.add(AclUpdatedEvent.create(this));
+
         return this;
     }
 
@@ -138,11 +153,11 @@ public class Acl extends AggregateRoot<AclID> {
     }
 
     public Set<Entry> getDirectEntries() {
-        return directEntries;
+        return Set.copyOf(directEntries);
     }
 
     public Set<Entry> getInheritedEntries() {
-        return inheritedEntries;
+        return Set.copyOf(inheritedEntries);
     }
 
     public Instant getCreatedAt() {

--- a/domain/src/main/java/com/callv2/drive/domain/access/Acl.java
+++ b/domain/src/main/java/com/callv2/drive/domain/access/Acl.java
@@ -7,6 +7,7 @@ import java.time.Instant;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import com.callv2.drive.domain.AggregateRoot;
@@ -68,6 +69,23 @@ public class Acl extends AggregateRoot<AclID> {
                 null,
                 now,
                 now);
+    }
+
+    public Acl createInherited(final Resource<?> resource) {
+        final Instant now = Instant.now();
+
+        final Set<Entry> inheritedEntries = Stream
+                .concat(this.directEntries.stream(), this.inheritedEntries.stream())
+                .collect(Collectors.toSet());
+
+        return new Acl(
+                AclID.unique(),
+                resource,
+                null,
+                inheritedEntries,
+                now,
+                now);
+
     }
 
     public Optional<AccessPermission> effectiveAccessPermission(final MemberID member) {

--- a/domain/src/main/java/com/callv2/drive/domain/access/Acl.java
+++ b/domain/src/main/java/com/callv2/drive/domain/access/Acl.java
@@ -88,6 +88,33 @@ public class Acl extends AggregateRoot<AclID> {
 
     }
 
+    public Acl grantTotal(final MemberID member) {
+        return this.grantEntry(member, AccessPermission.mostPrivileged(), SharePermission.mostPrivileged());
+    }
+
+    public Acl grantEntry(
+            MemberID member,
+            AccessPermission accessPermission,
+            SharePermission sharePermission) {
+
+        if (isNull(member))
+            throw new IllegalArgumentException("'member' should not be null");
+        if (isNull(accessPermission))
+            throw new IllegalArgumentException("'accessPermission' should not be null");
+        if (isNull(sharePermission))
+            throw new IllegalArgumentException("'sharePermission' should not be null");
+
+        final Entry entry = Entry.create(member, accessPermission, sharePermission);
+
+        if (this.directEntries.stream().anyMatch(e -> e.isEquivalentTo(entry)))
+            return this;
+
+        this.directEntries.add(entry);
+        this.updatedAt = Instant.now();
+
+        return this;
+    }
+
     public Optional<AccessPermission> effectiveAccessPermission(final MemberID member) {
 
         return Stream.concat(directEntries.stream(), inheritedEntries.stream())

--- a/domain/src/main/java/com/callv2/drive/domain/access/AclGateway.java
+++ b/domain/src/main/java/com/callv2/drive/domain/access/AclGateway.java
@@ -1,0 +1,11 @@
+package com.callv2.drive.domain.access;
+
+import java.util.Optional;
+
+public interface AclGateway {
+
+    Acl create(Acl acl);
+
+    Optional<Acl> findByResource(Resource<?> resource);
+
+}

--- a/domain/src/main/java/com/callv2/drive/domain/access/AclGateway.java
+++ b/domain/src/main/java/com/callv2/drive/domain/access/AclGateway.java
@@ -6,6 +6,8 @@ public interface AclGateway {
 
     Acl create(Acl acl);
 
+    Acl update(Acl acl);
+
     Optional<Acl> findByResource(Resource<?> resource);
 
 }

--- a/domain/src/main/java/com/callv2/drive/domain/access/AclID.java
+++ b/domain/src/main/java/com/callv2/drive/domain/access/AclID.java
@@ -19,8 +19,7 @@ public class AclID extends Identifier<UUID> {
         return getValue().toString();
     }
 
-    @Override
-    public AclID fromStringValue(String value) {
+    public static AclID fromStringValue(String value) {
         return AclID.of(UUID.fromString(value));
     }
 

--- a/domain/src/main/java/com/callv2/drive/domain/access/AclID.java
+++ b/domain/src/main/java/com/callv2/drive/domain/access/AclID.java
@@ -1,0 +1,30 @@
+package com.callv2.drive.domain.access;
+
+import java.util.UUID;
+
+import com.callv2.drive.domain.Identifier;
+
+public class AclID extends Identifier<UUID> {
+
+    public AclID(UUID value) {
+        super(value);
+    }
+
+    public static AclID of(final UUID id) {
+        return new AclID(id);
+    }
+
+    public String getStringValue() {
+        return getValue().toString();
+    }
+
+    public static AclID unique() {
+        return AclID.of(UUID.randomUUID());
+    }
+
+    @Override
+    public String toString() {
+        return "AccessID [value=" + getStringValue() + "]";
+    }
+
+}

--- a/domain/src/main/java/com/callv2/drive/domain/access/AclID.java
+++ b/domain/src/main/java/com/callv2/drive/domain/access/AclID.java
@@ -14,8 +14,14 @@ public class AclID extends Identifier<UUID> {
         return new AclID(id);
     }
 
+    @Override
     public String getStringValue() {
         return getValue().toString();
+    }
+
+    @Override
+    public AclID fromStringValue(String value) {
+        return AclID.of(UUID.fromString(value));
     }
 
     public static AclID unique() {

--- a/domain/src/main/java/com/callv2/drive/domain/access/AclUpdatedEvent.java
+++ b/domain/src/main/java/com/callv2/drive/domain/access/AclUpdatedEvent.java
@@ -1,0 +1,80 @@
+package com.callv2.drive.domain.access;
+
+import java.io.Serializable;
+import java.time.Instant;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import com.callv2.drive.domain.event.Event;
+import com.callv2.drive.domain.event.EventEntity;
+
+public class AclUpdatedEvent extends Event<AclUpdatedEvent.Data> {
+
+    private static final String ENTITY = "acl";
+    private static final String ACTION = "updated";
+    private static final String VERSION = "1.0.0";
+
+    private AclUpdatedEvent() {
+        super(ENTITY, ACTION, VERSION, null, null, null);
+    }
+
+    private AclUpdatedEvent(
+            final Instant occurredAt,
+            final Set<EventEntity> relatedEntities,
+            final AclUpdatedEvent.Data data) {
+        super(ENTITY, ACTION, VERSION, occurredAt, relatedEntities, data);
+    }
+
+    public record Data(
+            UUID aclId,
+            String resourceId,
+            ResourceType resourceType,
+            Set<Data.Entry> directEntries,
+            Set<Data.Entry> inheritedEntries,
+            Instant creadtedAt,
+            Instant updatedAt) implements Serializable {
+
+        public static Data of(final Acl acl) {
+            return new Data(
+                    acl.getId().getValue(),
+                    acl.getResource().id().getStringValue(),
+                    acl.getResource().type(),
+                    Entry.of(acl.getDirectEntries()),
+                    Entry.of(acl.getInheritedEntries()),
+                    acl.getCreatedAt(),
+                    acl.getUpdatedAt());
+        }
+
+        public record Entry(
+                UUID memberId,
+                AccessPermission accessPermission,
+                SharePermission sharePermission,
+                Instant grantedAt) implements Serializable {
+
+            public static Set<Data.Entry> of(final Set<com.callv2.drive.domain.access.Entry> entries) {
+                return entries.stream()
+                        .map(entry -> new Data.Entry(
+                                entry.member().getValue(),
+                                entry.accessPermission(),
+                                entry.sharePermission(),
+                                entry.grantedAt()))
+                        .collect(Collectors.toSet());
+            }
+
+        }
+
+    }
+
+    public static AclUpdatedEvent create(final Acl acl) {
+        return new AclUpdatedEvent(
+                Instant.now(),
+                Set.of(EventEntity.of(acl)),
+                Data.of(acl));
+    }
+
+    public static String eventKey() {
+        return new AclUpdatedEvent().key();
+    }
+
+}

--- a/domain/src/main/java/com/callv2/drive/domain/access/Entry.java
+++ b/domain/src/main/java/com/callv2/drive/domain/access/Entry.java
@@ -1,0 +1,23 @@
+package com.callv2.drive.domain.access;
+
+import java.time.Instant;
+import static java.util.Objects.isNull;
+import com.callv2.drive.domain.ValueObject;
+import com.callv2.drive.domain.member.MemberID;
+
+public record Entry(
+        MemberID member,
+        AccessPermission accessPermission,
+        SharePermission sharePermission,
+        Instant grantedAt) implements ValueObject {
+
+    public boolean isEquivalentTo(final Entry other) {
+
+        return isNull(other) ? false
+                : member.equals(other.member)
+                        && accessPermission.equals(other.accessPermission)
+                        && sharePermission.equals(other.sharePermission);
+
+    }
+
+}

--- a/domain/src/main/java/com/callv2/drive/domain/access/Entry.java
+++ b/domain/src/main/java/com/callv2/drive/domain/access/Entry.java
@@ -11,6 +11,13 @@ public record Entry(
         SharePermission sharePermission,
         Instant grantedAt) implements ValueObject {
 
+    public static Entry create(
+            final MemberID member,
+            final AccessPermission accessPermission,
+            final SharePermission sharePermission) {
+        return new Entry(member, accessPermission, sharePermission, Instant.now());
+    }
+
     public boolean isEquivalentTo(final Entry other) {
 
         return isNull(other) ? false

--- a/domain/src/main/java/com/callv2/drive/domain/access/Resource.java
+++ b/domain/src/main/java/com/callv2/drive/domain/access/Resource.java
@@ -1,0 +1,31 @@
+package com.callv2.drive.domain.access;
+
+import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
+
+import com.callv2.drive.domain.Identifier;
+import com.callv2.drive.domain.ValueObject;
+import com.callv2.drive.domain.validation.ValidationError;
+import com.callv2.drive.domain.validation.ValidationHandler;
+
+public record Resource<I>(Identifier<I> id, ResourceType type) implements ValueObject {
+
+    public static <I> Resource<I> of(final Identifier<I> id, final ResourceType type) {
+        return new Resource<>(id, type);
+    }
+
+    @Override
+    public void validate(final ValidationHandler handler) {
+
+        if (isNull(id))
+            handler.append(ValidationError.with("'id' cannot be null"));
+
+        if (isNull(type))
+            handler.append(ValidationError.with("'type' cannot be null"));
+
+        if (nonNull(id))
+            id.validate(handler);
+
+    }
+
+}

--- a/domain/src/main/java/com/callv2/drive/domain/access/Resource.java
+++ b/domain/src/main/java/com/callv2/drive/domain/access/Resource.java
@@ -5,13 +5,23 @@ import static java.util.Objects.nonNull;
 
 import com.callv2.drive.domain.Identifier;
 import com.callv2.drive.domain.ValueObject;
+import com.callv2.drive.domain.file.FileID;
+import com.callv2.drive.domain.folder.FolderID;
 import com.callv2.drive.domain.validation.ValidationError;
 import com.callv2.drive.domain.validation.ValidationHandler;
 
-public record Resource<I>(Identifier<I> id, ResourceType type) implements ValueObject {
+public record Resource<I extends Identifier<?>>(I id, ResourceType type) implements ValueObject {
 
-    public static <I> Resource<I> of(final Identifier<I> id, final ResourceType type) {
+    public static <I extends Identifier<?>> Resource<I> of(final I id, final ResourceType type) {
         return new Resource<>(id, type);
+    }
+
+    public static Resource<FolderID> folder(final FolderID id) {
+        return new Resource<>(id, ResourceType.FOLDER);
+    }
+
+    public static Resource<FileID> file(final FileID id) {
+        return new Resource<>(id, ResourceType.FILE);
     }
 
     @Override

--- a/domain/src/main/java/com/callv2/drive/domain/access/ResourceType.java
+++ b/domain/src/main/java/com/callv2/drive/domain/access/ResourceType.java
@@ -1,0 +1,6 @@
+package com.callv2.drive.domain.access;
+
+public enum ResourceType {
+    FILE,
+    FOLDER
+}

--- a/domain/src/main/java/com/callv2/drive/domain/access/SharePermission.java
+++ b/domain/src/main/java/com/callv2/drive/domain/access/SharePermission.java
@@ -1,7 +1,7 @@
 package com.callv2.drive.domain.access;
 
 public enum SharePermission {
-    SHARE_TO_SHARE(0),
+    SHARE_TO_SHARE(0), // TODO verirify if this is correct
     SHARE_WRITE(1),
     SHARE_READ(2);
 

--- a/domain/src/main/java/com/callv2/drive/domain/access/SharePermission.java
+++ b/domain/src/main/java/com/callv2/drive/domain/access/SharePermission.java
@@ -1,0 +1,17 @@
+package com.callv2.drive.domain.access;
+
+public enum SharePermission {
+    SHARE_TO_SHARE(0),
+    SHARE_WRITE(1),
+    SHARE_READ(2);
+
+    private final Integer level;
+
+    private SharePermission(int level) {
+        this.level = level;
+    }
+
+    public Integer getLevel() {
+        return level;
+    }
+}

--- a/domain/src/main/java/com/callv2/drive/domain/access/SharePermission.java
+++ b/domain/src/main/java/com/callv2/drive/domain/access/SharePermission.java
@@ -14,4 +14,9 @@ public enum SharePermission {
     public Integer getLevel() {
         return level;
     }
+
+    public static SharePermission mostPrivileged() {
+        return SHARE_TO_SHARE;
+    }
+
 }

--- a/domain/src/main/java/com/callv2/drive/domain/file/File.java
+++ b/domain/src/main/java/com/callv2/drive/domain/file/File.java
@@ -170,7 +170,12 @@ public class File extends AggregateRoot<FileID> implements EventSource {
         if (this.isDeleted)
             return this;
 
-        this.deletedAt = Instant.now();
+        final Instant now = Instant.now();
+
+        this.updatedBy = deleterId;
+        this.updatedAt = now;
+        this.deletedBy = deleterId;
+        this.deletedAt = now;
         this.isDeleted = true;
 
         this.events.add(FileDeletedEvent.create(this, deleterId));

--- a/domain/src/main/java/com/callv2/drive/domain/file/File.java
+++ b/domain/src/main/java/com/callv2/drive/domain/file/File.java
@@ -26,6 +26,9 @@ public class File extends AggregateRoot<FileID> implements EventSource {
     private FileName name;
     private Content content;
 
+    private MemberID updatedBy;
+    private MemberID deletedBy;
+
     private Instant createdAt;
     private Instant updatedAt;
     private Instant deletedAt;
@@ -39,6 +42,8 @@ public class File extends AggregateRoot<FileID> implements EventSource {
             final FolderID folder,
             final FileName name,
             final Content content,
+            final MemberID updatedBy,
+            final MemberID deletedBy,
             final Instant createdAt,
             final Instant updatedAt,
             final Instant deletedAt,
@@ -50,6 +55,8 @@ public class File extends AggregateRoot<FileID> implements EventSource {
         this.owner = owner;
         this.name = name;
         this.content = content;
+        this.updatedBy = updatedBy;
+        this.deletedBy = deletedBy;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
         this.deletedAt = deletedAt;
@@ -72,11 +79,25 @@ public class File extends AggregateRoot<FileID> implements EventSource {
             final FolderID folder,
             final FileName name,
             final Content content,
+            final MemberID updatedBy,
+            final MemberID deletedBy,
             final Instant createdAt,
             final Instant updatedAt,
             final Instant deletedAt,
             final Boolean isDeleted) {
-        return new File(id, creator, owner, folder, name, content, createdAt, updatedAt, deletedAt, isDeleted);
+        return new File(
+                id,
+                creator,
+                owner,
+                folder,
+                name,
+                content,
+                updatedBy,
+                deletedBy,
+                createdAt,
+                updatedAt,
+                deletedAt,
+                isDeleted);
     }
 
     public static File with(final File file) {
@@ -87,6 +108,8 @@ public class File extends AggregateRoot<FileID> implements EventSource {
                 file.getFolder(),
                 file.getName(),
                 file.getContent(),
+                file.getUpdatedBy(),
+                file.getDeletedBy(),
                 file.getCreatedAt(),
                 file.getUpdatedAt(),
                 file.getDeletedAt(),
@@ -114,6 +137,8 @@ public class File extends AggregateRoot<FileID> implements EventSource {
                 folder,
                 name,
                 content,
+                creator,
+                null,
                 now,
                 now,
                 null,
@@ -121,6 +146,7 @@ public class File extends AggregateRoot<FileID> implements EventSource {
     }
 
     public File update(
+            final MemberID updater,
             final FolderID folder,
             final FileName name,
             final Content content) {
@@ -132,13 +158,14 @@ public class File extends AggregateRoot<FileID> implements EventSource {
         this.name = name;
         this.content = content;
 
+        this.updatedBy = updater;
         this.updatedAt = Instant.now();
 
         selfValidate();
         return this;
     }
 
-    public File delete() {
+    public File delete(final MemberID deleterId) {
 
         if (this.isDeleted)
             return this;
@@ -146,7 +173,7 @@ public class File extends AggregateRoot<FileID> implements EventSource {
         this.deletedAt = Instant.now();
         this.isDeleted = true;
 
-        this.events.add(FileDeletedEvent.create(this));
+        this.events.add(FileDeletedEvent.create(this, deleterId));
 
         return this;
 
@@ -158,6 +185,10 @@ public class File extends AggregateRoot<FileID> implements EventSource {
 
         if (notification.hasError())
             throw ValidationException.with("Validation fail has occoured", notification);
+    }
+
+    public Queue<Event<?>> getEvents() {
+        return events;
     }
 
     public MemberID getCreator() {
@@ -178,6 +209,14 @@ public class File extends AggregateRoot<FileID> implements EventSource {
 
     public Content getContent() {
         return content;
+    }
+
+    public MemberID getUpdatedBy() {
+        return updatedBy;
+    }
+
+    public MemberID getDeletedBy() {
+        return deletedBy;
     }
 
     public Instant getCreatedAt() {
@@ -204,10 +243,13 @@ public class File extends AggregateRoot<FileID> implements EventSource {
                 + ", folder=" + folder
                 + ", name=" + name
                 + ", content=" + content
+                + ", updatedBy=" + updatedBy
+                + ", deletedBy=" + deletedBy
                 + ", createdAt=" + createdAt
                 + ", updatedAt=" + updatedAt
                 + ", deletedAt=" + deletedAt
-                + ", isDeleted=" + isDeleted + "]";
+                + ", isDeleted=" + isDeleted
+                + "]";
     }
 
 }

--- a/domain/src/main/java/com/callv2/drive/domain/file/File.java
+++ b/domain/src/main/java/com/callv2/drive/domain/file/File.java
@@ -18,6 +18,7 @@ public class File extends AggregateRoot<FileID> implements EventSource {
 
     private Queue<Event<?>> events;
 
+    private MemberID creator;
     private MemberID owner;
 
     private FolderID folder;
@@ -33,6 +34,7 @@ public class File extends AggregateRoot<FileID> implements EventSource {
 
     private File(
             final FileID anId,
+            final MemberID creator,
             final MemberID owner,
             final FolderID folder,
             final FileName name,
@@ -44,6 +46,7 @@ public class File extends AggregateRoot<FileID> implements EventSource {
         super(anId);
 
         this.folder = folder;
+        this.creator = creator;
         this.owner = owner;
         this.name = name;
         this.content = content;
@@ -64,6 +67,7 @@ public class File extends AggregateRoot<FileID> implements EventSource {
 
     public static File with(
             final FileID id,
+            final MemberID creator,
             final MemberID owner,
             final FolderID folder,
             final FileName name,
@@ -72,12 +76,13 @@ public class File extends AggregateRoot<FileID> implements EventSource {
             final Instant updatedAt,
             final Instant deletedAt,
             final Boolean isDeleted) {
-        return new File(id, owner, folder, name, content, createdAt, updatedAt, deletedAt, isDeleted);
+        return new File(id, creator, owner, folder, name, content, createdAt, updatedAt, deletedAt, isDeleted);
     }
 
     public static File with(final File file) {
         return File.with(
                 file.getId(),
+                file.getCreator(),
                 file.getOwner(),
                 file.getFolder(),
                 file.getName(),
@@ -94,6 +99,7 @@ public class File extends AggregateRoot<FileID> implements EventSource {
     }
 
     public static File create(
+            final MemberID creator,
             final MemberID owner,
             final FolderID folder,
             final FileName name,
@@ -103,6 +109,7 @@ public class File extends AggregateRoot<FileID> implements EventSource {
 
         return new File(
                 FileID.unique(),
+                creator,
                 owner,
                 folder,
                 name,
@@ -153,6 +160,10 @@ public class File extends AggregateRoot<FileID> implements EventSource {
             throw ValidationException.with("Validation fail has occoured", notification);
     }
 
+    public MemberID getCreator() {
+        return creator;
+    }
+
     public MemberID getOwner() {
         return owner;
     }
@@ -187,9 +198,16 @@ public class File extends AggregateRoot<FileID> implements EventSource {
 
     @Override
     public String toString() {
-        return "File [id=" + id + ", owner=" + owner + ", folder=" + folder + ", name=" + name + ", content=" + content
-                + ", createdAt=" + createdAt + ", updatedAt=" + updatedAt + ", deletedAt=" + deletedAt + ", isDeleted="
-                + isDeleted + "]";
+        return "File [id=" + id
+                + ", creator=" + creator
+                + ", owner=" + owner
+                + ", folder=" + folder
+                + ", name=" + name
+                + ", content=" + content
+                + ", createdAt=" + createdAt
+                + ", updatedAt=" + updatedAt
+                + ", deletedAt=" + deletedAt
+                + ", isDeleted=" + isDeleted + "]";
     }
 
 }

--- a/domain/src/main/java/com/callv2/drive/domain/file/FileDeletedEvent.java
+++ b/domain/src/main/java/com/callv2/drive/domain/file/FileDeletedEvent.java
@@ -29,7 +29,7 @@ public class FileDeletedEvent extends Event<FileDeletedEvent.Data> {
 
     public record Data(
             UUID fileId,
-            String ownerId,
+            UUID ownerId,
             UUID folderId,
             String name,
             String storageKey,

--- a/domain/src/main/java/com/callv2/drive/domain/file/FileDeletedEvent.java
+++ b/domain/src/main/java/com/callv2/drive/domain/file/FileDeletedEvent.java
@@ -9,6 +9,7 @@ import com.callv2.drive.domain.event.Event;
 import com.callv2.drive.domain.event.EventEntity;
 import com.callv2.drive.domain.folder.Folder;
 import com.callv2.drive.domain.member.Member;
+import com.callv2.drive.domain.member.MemberID;
 
 public class FileDeletedEvent extends Event<FileDeletedEvent.Data> {
 
@@ -28,6 +29,7 @@ public class FileDeletedEvent extends Event<FileDeletedEvent.Data> {
     }
 
     public record Data(
+            UUID deleterId,
             UUID fileId,
             UUID ownerId,
             UUID folderId,
@@ -39,8 +41,9 @@ public class FileDeletedEvent extends Event<FileDeletedEvent.Data> {
             Instant updatedAt,
             Instant deletedAt) implements Serializable {
 
-        public static Data of(final File file) {
+        public static Data of(final File file, final MemberID deleterId) {
             return new Data(
+                    deleterId.getValue(),
                     file.getId().getValue(),
                     file.getOwner().getValue(),
                     file.getFolder().getValue(),
@@ -54,14 +57,14 @@ public class FileDeletedEvent extends Event<FileDeletedEvent.Data> {
         }
     }
 
-    public static FileDeletedEvent create(final File file) {
+    public static FileDeletedEvent create(final File file, final MemberID deleterId) {
         return new FileDeletedEvent(
                 Instant.now(),
                 Set.of(
                         EventEntity.of(file),
                         EventEntity.of(Member.class, file.getOwner()),
                         EventEntity.of(Folder.class, file.getFolder())),
-                Data.of(file));
+                Data.of(file, deleterId));
     }
 
     public static String eventKey() {

--- a/domain/src/main/java/com/callv2/drive/domain/file/FileGateway.java
+++ b/domain/src/main/java/com/callv2/drive/domain/file/FileGateway.java
@@ -16,7 +16,7 @@ public interface FileGateway {
 
     Optional<File> findByIdWithMemberAccess(final FileID id, final MemberID memberId);
 
-    List<File> findByFolder(FolderID folderId);
+    List<File> findAllActiveByFolder(FolderID folderId);
 
     List<File> findByOwner(MemberID ownerId);
 

--- a/domain/src/main/java/com/callv2/drive/domain/file/FileGateway.java
+++ b/domain/src/main/java/com/callv2/drive/domain/file/FileGateway.java
@@ -14,7 +14,7 @@ public interface FileGateway {
 
     File update(File file);
 
-    Optional<File> findById(FileID id);
+    Optional<File> findByIdWithMemberAccess(final FileID id, final MemberID memberId);
 
     List<File> findByFolder(FolderID folderId);
 

--- a/domain/src/main/java/com/callv2/drive/domain/file/FileGateway.java
+++ b/domain/src/main/java/com/callv2/drive/domain/file/FileGateway.java
@@ -20,7 +20,7 @@ public interface FileGateway {
 
     List<File> findByOwner(MemberID ownerId);
 
-    Page<File> findAll(SearchQuery searchQuery);
+    Page<File> findAllWithMemberAccess(SearchQuery searchQuery, MemberID memberId);
 
     void deleteById(FileID id);
 

--- a/domain/src/main/java/com/callv2/drive/domain/file/FileID.java
+++ b/domain/src/main/java/com/callv2/drive/domain/file/FileID.java
@@ -23,8 +23,7 @@ public class FileID extends Identifier<UUID> {
         return getValue().toString();
     }
 
-    @Override
-    public FileID fromStringValue(final String value) {
+    public static FileID fromStringValue(final String value) {
         return FileID.of(UUID.fromString(value));
     }
 

--- a/domain/src/main/java/com/callv2/drive/domain/file/FileID.java
+++ b/domain/src/main/java/com/callv2/drive/domain/file/FileID.java
@@ -24,6 +24,11 @@ public class FileID extends Identifier<UUID> {
     }
 
     @Override
+    public FileID fromStringValue(final String value) {
+        return FileID.of(UUID.fromString(value));
+    }
+
+    @Override
     public String toString() {
         return "FileID [value=" + getValue() + "]";
     }

--- a/domain/src/main/java/com/callv2/drive/domain/folder/Folder.java
+++ b/domain/src/main/java/com/callv2/drive/domain/folder/Folder.java
@@ -13,6 +13,7 @@ public class Folder extends AggregateRoot<FolderID> {
 
     private boolean rootFolder;
 
+    private MemberID creator;
     private MemberID owner;
 
     private FolderName name;
@@ -24,6 +25,7 @@ public class Folder extends AggregateRoot<FolderID> {
 
     private Folder(
             final FolderID id,
+            final MemberID creator,
             final MemberID owner,
             final FolderName name,
             final FolderID parentFolder,
@@ -34,6 +36,7 @@ public class Folder extends AggregateRoot<FolderID> {
         super(id);
 
         this.owner = owner;
+        this.creator = creator;
         this.name = name;
         this.parentFolder = parentFolder;
         this.createdAt = createdAt;
@@ -46,6 +49,7 @@ public class Folder extends AggregateRoot<FolderID> {
 
     public static Folder with(
             final FolderID id,
+            final MemberID creator,
             final MemberID owner,
             final FolderName name,
             final FolderID parentFolder,
@@ -53,15 +57,16 @@ public class Folder extends AggregateRoot<FolderID> {
             final Instant updatedAt,
             final Instant deletedAt,
             final boolean rootFolder) {
-        return new Folder(id, owner, name, parentFolder, createdAt, updatedAt, deletedAt, rootFolder);
+        return new Folder(id, creator, owner, name, parentFolder, createdAt, updatedAt, deletedAt, rootFolder);
     }
 
-    public static Folder createRoot(final MemberID owner) {
+    public static Folder createRoot(final MemberID creator) {
         Instant now = Instant.now();
 
         return Folder.with(
                 FolderID.unique(),
-                owner,
+                creator,
+                creator,
                 FolderName.of("Root"),
                 null,
                 now,
@@ -71,6 +76,7 @@ public class Folder extends AggregateRoot<FolderID> {
     }
 
     public static Folder create(
+            final MemberID creator,
             final MemberID owner,
             final FolderName name,
             final Folder parentFolder) {
@@ -79,6 +85,7 @@ public class Folder extends AggregateRoot<FolderID> {
 
         final var folder = Folder.with(
                 FolderID.unique(),
+                creator,
                 owner,
                 name,
                 parentFolder.getId(),
@@ -123,20 +130,32 @@ public class Folder extends AggregateRoot<FolderID> {
         return this;
     }
 
+    private void selfValidate() {
+        final var notification = Notification.create();
+        validate(notification);
+
+        if (notification.hasError())
+            throw ValidationException.with("Validation fail has occoured", notification);
+    }
+
     public boolean isRootFolder() {
         return rootFolder;
+    }
+
+    public MemberID getCreator() {
+        return creator;
     }
 
     public MemberID getOwner() {
         return owner;
     }
 
-    public FolderID getParentFolder() {
-        return parentFolder;
-    }
-
     public FolderName getName() {
         return name;
+    }
+
+    public FolderID getParentFolder() {
+        return parentFolder;
     }
 
     public Instant getCreatedAt() {
@@ -151,19 +170,18 @@ public class Folder extends AggregateRoot<FolderID> {
         return deletedAt;
     }
 
-    private void selfValidate() {
-        final var notification = Notification.create();
-        validate(notification);
-
-        if (notification.hasError())
-            throw ValidationException.with("Validation fail has occoured", notification);
-    }
-
     @Override
     public String toString() {
-        return "Folder [id=" + id + ", rootFolder=" + rootFolder + ", owner=" + owner + ", name=" + name
-                + ", parentFolder=" + parentFolder + ", createdAt=" + createdAt + ", updatedAt=" + updatedAt
-                + ", deletedAt=" + deletedAt + "]";
+        return "Folder [id=" + id
+                + ", rootFolder=" + rootFolder
+                + ", creator=" + creator
+                + ", owner=" + owner
+                + ", name=" + name
+                + ", parentFolder=" + parentFolder
+                + ", createdAt=" + createdAt
+                + ", updatedAt=" + updatedAt
+                + ", deletedAt=" + deletedAt
+                + "]";
     }
 
 }

--- a/domain/src/main/java/com/callv2/drive/domain/folder/FolderGateway.java
+++ b/domain/src/main/java/com/callv2/drive/domain/folder/FolderGateway.java
@@ -10,7 +10,7 @@ import com.callv2.drive.domain.pagination.SearchQuery;
 
 public interface FolderGateway {
 
-    Optional<Folder> findRoot(MemberID owner);
+    Optional<Folder> findMemberRootFolder(MemberID owner);
 
     Set<Folder> findByParentFolderId(FolderID parentFolderId);
 

--- a/domain/src/main/java/com/callv2/drive/domain/folder/FolderGateway.java
+++ b/domain/src/main/java/com/callv2/drive/domain/folder/FolderGateway.java
@@ -4,12 +4,13 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
+import com.callv2.drive.domain.member.MemberID;
 import com.callv2.drive.domain.pagination.Page;
 import com.callv2.drive.domain.pagination.SearchQuery;
 
 public interface FolderGateway {
 
-    Optional<Folder> findRoot();
+    Optional<Folder> findRoot(MemberID owner);
 
     Set<Folder> findByParentFolderId(FolderID parentFolderId);
 

--- a/domain/src/main/java/com/callv2/drive/domain/folder/FolderGateway.java
+++ b/domain/src/main/java/com/callv2/drive/domain/folder/FolderGateway.java
@@ -20,9 +20,9 @@ public interface FolderGateway {
 
     void updateAll(List<Folder> folders);
 
-    Optional<Folder> findById(FolderID id);
+    Optional<Folder> findByIdWithMemberAccess(FolderID id, MemberID actorId);
 
-    Page<Folder> findAll(final SearchQuery searchQuery);
+    Page<Folder> findAllWithMemberAccess(SearchQuery searchQuery, MemberID actorId);
 
     void deleteById(FolderID id);
 

--- a/domain/src/main/java/com/callv2/drive/domain/folder/FolderGateway.java
+++ b/domain/src/main/java/com/callv2/drive/domain/folder/FolderGateway.java
@@ -12,7 +12,7 @@ public interface FolderGateway {
 
     Optional<Folder> findMemberRootFolder(MemberID owner);
 
-    Set<Folder> findByParentFolderId(FolderID parentFolderId);
+    Set<Folder> findByParentFolderIdWithMemberAccess(FolderID parentFolderId, final MemberID actorId);
 
     Folder create(Folder folder);
 

--- a/domain/src/main/java/com/callv2/drive/domain/folder/FolderID.java
+++ b/domain/src/main/java/com/callv2/drive/domain/folder/FolderID.java
@@ -19,8 +19,7 @@ public class FolderID extends Identifier<UUID> {
         return getValue().toString();
     }
 
-    @Override
-    public FolderID fromStringValue(String value) {
+    public static FolderID fromStringValue(String value) {
         return FolderID.of(UUID.fromString(value));
     }
 

--- a/domain/src/main/java/com/callv2/drive/domain/folder/FolderID.java
+++ b/domain/src/main/java/com/callv2/drive/domain/folder/FolderID.java
@@ -14,8 +14,14 @@ public class FolderID extends Identifier<UUID> {
         return new FolderID(id);
     }
 
+    @Override
     public String getStringValue() {
         return getValue().toString();
+    }
+
+    @Override
+    public FolderID fromStringValue(String value) {
+        return FolderID.of(UUID.fromString(value));
     }
 
     public static FolderID unique() {

--- a/domain/src/main/java/com/callv2/drive/domain/member/Member.java
+++ b/domain/src/main/java/com/callv2/drive/domain/member/Member.java
@@ -79,7 +79,7 @@ public class Member extends AggregateRoot<MemberID> {
         if (!this.id.equals(member.id))
             throw IdMismatchException.with(
                     Member.class,
-                    member.id.getValue());
+                    member.id.getStringValue());
 
         if (this.synchronizedVersion > member.synchronizedVersion)
             throw SynchronizedVersionOutdatedException

--- a/domain/src/main/java/com/callv2/drive/domain/member/MemberID.java
+++ b/domain/src/main/java/com/callv2/drive/domain/member/MemberID.java
@@ -1,20 +1,22 @@
 package com.callv2.drive.domain.member;
 
+import java.util.UUID;
+
 import com.callv2.drive.domain.Identifier;
 
-public class MemberID extends Identifier<String> {
+public class MemberID extends Identifier<UUID> {
 
-    public MemberID(String value) {
+    public MemberID(final UUID value) {
         super(value);
     }
 
-    public static MemberID of(final String id) {
+    public static MemberID of(final UUID id) {
         return new MemberID(id);
     }
 
     @Override
     public String getStringValue() {
-        return getValue();
+        return getValue().toString();
     }
 
     @Override

--- a/domain/src/main/java/com/callv2/drive/domain/member/MemberID.java
+++ b/domain/src/main/java/com/callv2/drive/domain/member/MemberID.java
@@ -14,8 +14,7 @@ public class MemberID extends Identifier<UUID> {
         return new MemberID(id);
     }
 
-    @Override
-    public MemberID fromStringValue(final String value) {
+    public static MemberID fromStringValue(final String value) {
         return MemberID.of(UUID.fromString(value));
     }
 

--- a/domain/src/main/java/com/callv2/drive/domain/member/MemberID.java
+++ b/domain/src/main/java/com/callv2/drive/domain/member/MemberID.java
@@ -15,6 +15,11 @@ public class MemberID extends Identifier<UUID> {
     }
 
     @Override
+    public MemberID fromStringValue(final String value) {
+        return MemberID.of(UUID.fromString(value));
+    }
+
+    @Override
     public String getStringValue() {
         return getValue().toString();
     }

--- a/domain/src/main/java/com/callv2/drive/domain/member/QuotaRequestPreview.java
+++ b/domain/src/main/java/com/callv2/drive/domain/member/QuotaRequestPreview.java
@@ -1,9 +1,10 @@
 package com.callv2.drive.domain.member;
 
 import java.time.Instant;
+import java.util.UUID;
 
 public record QuotaRequestPreview(
-        String memberId,
+        UUID memberId,
         String memberUsername,
         String memberNickname,
         long quotaAmount,

--- a/domain/src/main/java/com/callv2/drive/domain/storage/StorageGateway.java
+++ b/domain/src/main/java/com/callv2/drive/domain/storage/StorageGateway.java
@@ -2,7 +2,7 @@ package com.callv2.drive.domain.storage;
 
 import java.io.InputStream;
 
-public interface StorageService {
+public interface StorageGateway {
 
     void store(String key, InputStream content);
 

--- a/domain/src/main/java/com/callv2/drive/domain/storage/StorageKeyGenerator.java
+++ b/domain/src/main/java/com/callv2/drive/domain/storage/StorageKeyGenerator.java
@@ -1,0 +1,7 @@
+package com.callv2.drive.domain.storage;
+
+public interface StorageKeyGenerator {
+
+    String generate();
+
+}

--- a/domain/src/test/java/com/callv2/drive/domain/file/FileTest.java
+++ b/domain/src/test/java/com/callv2/drive/domain/file/FileTest.java
@@ -6,6 +6,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.UUID;
+
 import org.junit.jupiter.api.Test;
 
 import com.callv2.drive.domain.exception.ValidationException;
@@ -17,10 +19,9 @@ public class FileTest {
     @Test
     void givenAValidParams_whenCallsCreate_thenShouldCreateFile() {
 
-        final var ownerId = MemberID.of("owner");
-
-        final var expectedOwner = MemberID.of("owner");
-        final var expectedFolder = Folder.createRoot(ownerId).getId();
+        final var expectedCreator = MemberID.of(UUID.randomUUID());
+        final var expectedOwner = MemberID.of(UUID.randomUUID());
+        final var expectedFolder = Folder.createRoot(expectedOwner).getId();
 
         final var expectedName = "file";
 
@@ -30,8 +31,9 @@ public class FileTest {
         final var content = Content.of(expectedContentLocation, expectedContentType, expectedContentSize);
 
         final var actualFile = assertDoesNotThrow(
-                () -> File.create(expectedOwner, expectedFolder, FileName.of(expectedName), content));
+                () -> File.create(expectedCreator, expectedOwner, expectedFolder, FileName.of(expectedName), content));
 
+        assertEquals(expectedCreator, actualFile.getCreator());
         assertEquals(expectedOwner, actualFile.getOwner());
         assertEquals(expectedName, actualFile.getName().value());
         assertEquals(expectedContentType, actualFile.getContent().type());
@@ -45,7 +47,8 @@ public class FileTest {
     @Test
     void givenEmptyName_whenCallsCreate_thenShouldThrowsValidationException() {
 
-        final var expectedOwner = MemberID.of("owner");
+        final var expectedCreator = MemberID.of(UUID.randomUUID());
+        final var expectedOwner = MemberID.of(UUID.randomUUID());
         final var expectedFolder = Folder.createRoot(expectedOwner).getId();
 
         final var expectedName = "";
@@ -61,7 +64,7 @@ public class FileTest {
 
         final var actualException = assertThrows(
                 ValidationException.class,
-                () -> File.create(expectedOwner, expectedFolder, FileName.of(expectedName), content));
+                () -> File.create(expectedCreator, expectedOwner, expectedFolder, FileName.of(expectedName), content));
 
         assertEquals(expectedExceptionMessage, actualException.getMessage());
         assertEquals(expectedErrorsCount, actualException.getErrors().size());
@@ -71,7 +74,8 @@ public class FileTest {
     @Test
     void givenNullName_whenCallsCreate_thenShouldThrowsValidationException() {
 
-        final var expectedOwner = MemberID.of("owner");
+        final var expectedCreator = MemberID.of(UUID.randomUUID());
+        final var expectedOwner = MemberID.of(UUID.randomUUID());
         final var expectedFolder = Folder.createRoot(expectedOwner).getId();
 
         final String expectedName = null;
@@ -88,6 +92,7 @@ public class FileTest {
         final var actualException = assertThrows(
                 ValidationException.class,
                 () -> File.create(
+                        expectedCreator,
                         expectedOwner,
                         expectedFolder,
                         FileName.of(expectedName),
@@ -101,7 +106,8 @@ public class FileTest {
     @Test
     void givenNameWithMoreThan64Chars_whenCallsCreate_thenShouldThrowsValidationException() {
 
-        final var expectedOwner = MemberID.of("owner");
+        final var expectedCreator = MemberID.of(UUID.randomUUID());
+        final var expectedOwner = MemberID.of(UUID.randomUUID());
         final var expectedFolder = Folder.createRoot(expectedOwner).getId();
 
         final var expectedName = """
@@ -120,6 +126,7 @@ public class FileTest {
         final var actualException = assertThrows(
                 ValidationException.class,
                 () -> File.create(
+                        expectedCreator,
                         expectedOwner,
                         expectedFolder,
                         FileName.of(expectedName),
@@ -134,7 +141,8 @@ public class FileTest {
     @Test
     void givenReservedName_whenCallsCreate_thenShouldThrowsValidationException() {
 
-        final var expectedOwner = MemberID.of("owner");
+        final var expectedCreator = MemberID.of(UUID.randomUUID());
+        final var expectedOwner = MemberID.of(UUID.randomUUID());
         final var expectedFolder = Folder.createRoot(expectedOwner).getId();
 
         final var expectedName = "nul";
@@ -151,6 +159,7 @@ public class FileTest {
         final var actualException = assertThrows(
                 ValidationException.class,
                 () -> File.create(
+                        expectedCreator,
                         expectedOwner,
                         expectedFolder,
                         FileName.of(expectedName),
@@ -165,7 +174,8 @@ public class FileTest {
     @Test
     void givenMultipleInvalidParams_whenCallsCreate_thenShouldThrowsValidationExceptionWithMultipleErrors() {
 
-        final var expectedOwner = MemberID.of("owner");
+        final var expectedCreator = MemberID.of(UUID.randomUUID());
+        final var expectedOwner = MemberID.of(UUID.randomUUID());
         final var expectedFolder = Folder.createRoot(expectedOwner).getId();
 
         final String expectedName = "nul";
@@ -182,6 +192,7 @@ public class FileTest {
         final var actualException = assertThrows(
                 ValidationException.class,
                 () -> File.create(
+                        expectedCreator,
                         expectedOwner,
                         expectedFolder,
                         FileName.of(expectedName),
@@ -197,7 +208,8 @@ public class FileTest {
     @Test
     void givenAValidParams_whenCallsUpdate_thenShouldCreateFile() {
 
-        final var expectedOwner = MemberID.of("owner");
+        final var expectedCreator = MemberID.of(UUID.randomUUID());
+        final var expectedOwner = MemberID.of(UUID.randomUUID());
         final var expectedFolder = Folder.createRoot(expectedOwner).getId();
 
         final var expectedName = FileName.of("File");
@@ -208,6 +220,7 @@ public class FileTest {
         final var content = Content.of(expectedContentLocation, expectedContentType, expectedContentSize);
 
         final var aFile = File.create(
+                expectedCreator,
                 expectedOwner,
                 expectedFolder,
                 FileName.of("file"),
@@ -228,7 +241,8 @@ public class FileTest {
     @Test
     void givenEmptyName_whenCallsUpdate_thenShouldThrowsValidationException() {
 
-        final var expectedOwner = MemberID.of("owner");
+        final var expectedCreator = MemberID.of(UUID.randomUUID());
+        final var expectedOwner = MemberID.of(UUID.randomUUID());
         final var expectedFolder = Folder.createRoot(expectedOwner).getId();
 
         final var expectedName = "";
@@ -242,7 +256,7 @@ public class FileTest {
         final var expectedErrorsCount = 1;
         final var expectedErrorMessage = "'name' cannot be empty.";
 
-        final var aFile = File.create(expectedOwner, expectedFolder, FileName.of("file"), content);
+        final var aFile = File.create(expectedCreator, expectedOwner, expectedFolder, FileName.of("file"), content);
 
         final var actualException = assertThrows(ValidationException.class,
                 () -> File.with(aFile).update(expectedFolder, FileName.of(expectedName), content));
@@ -255,7 +269,8 @@ public class FileTest {
     @Test
     void givenNullName_whenCallsUpdate_thenShouldThrowsValidationException() {
 
-        final var expectedOwner = MemberID.of("owner");
+        final var expectedCreator = MemberID.of(UUID.randomUUID());
+        final var expectedOwner = MemberID.of(UUID.randomUUID());
         final var expectedFolder = Folder.createRoot(expectedOwner).getId();
 
         final String expectedName = null;
@@ -269,7 +284,7 @@ public class FileTest {
         final var expectedErrorsCount = 1;
         final var expectedErrorMessage = "'name' cannot be null.";
 
-        final var aFile = File.create(expectedOwner, expectedFolder, FileName.of("file"), content);
+        final var aFile = File.create(expectedCreator, expectedOwner, expectedFolder, FileName.of("file"), content);
 
         final var actualException = assertThrows(ValidationException.class,
                 () -> File.with(aFile).update(expectedFolder, FileName.of(expectedName), content));
@@ -283,7 +298,8 @@ public class FileTest {
     @Test
     void givenNameWithMoreThan64Chars_whenCallsUpdate_thenShouldThrowsValidationException() {
 
-        final var expectedOwner = MemberID.of("owner");
+        final var expectedCreator = MemberID.of(UUID.randomUUID());
+        final var expectedOwner = MemberID.of(UUID.randomUUID());
         final var expectedFolder = Folder.createRoot(expectedOwner).getId();
 
         final var expectedName = """
@@ -299,7 +315,7 @@ public class FileTest {
         final var expectedErrorsCount = 1;
         final var expectedErrorMessage = "'name' must be between 1 and 64 characters.";
 
-        final var aFile = File.create(expectedOwner, expectedFolder, FileName.of("file"), content);
+        final var aFile = File.create(expectedCreator, expectedOwner, expectedFolder, FileName.of("file"), content);
 
         final var actualException = assertThrows(ValidationException.class,
                 () -> File.with(aFile).update(expectedFolder, FileName.of(expectedName), content));
@@ -313,7 +329,8 @@ public class FileTest {
     @Test
     void givenReservedName_whenCallsUpdate_thenShouldThrowsValidationException() {
 
-        final var expectedOwner = MemberID.of("owner");
+        final var expectedCreator = MemberID.of(UUID.randomUUID());
+        final var expectedOwner = MemberID.of(UUID.randomUUID());
         final var expectedFolder = Folder.createRoot(expectedOwner).getId();
 
         final var expectedName = "nul";
@@ -327,7 +344,7 @@ public class FileTest {
         final var expectedErrorsCount = 1;
         final var expectedErrorMessage = "'name' cannot be a reserved name: %s".formatted(expectedName);
 
-        final var aFile = File.create(expectedOwner, expectedFolder, FileName.of("file"), content);
+        final var aFile = File.create(expectedCreator, expectedOwner, expectedFolder, FileName.of("file"), content);
 
         final var actualException = assertThrows(ValidationException.class,
                 () -> File.with(aFile).update(expectedFolder, FileName.of(expectedName), content));

--- a/domain/src/test/java/com/callv2/drive/domain/file/FileTest.java
+++ b/domain/src/test/java/com/callv2/drive/domain/file/FileTest.java
@@ -211,6 +211,7 @@ public class FileTest {
         final var expectedCreator = MemberID.of(UUID.randomUUID());
         final var expectedOwner = MemberID.of(UUID.randomUUID());
         final var expectedFolder = Folder.createRoot(expectedOwner).getId();
+        final var expectedActorId = expectedOwner;
 
         final var expectedName = FileName.of("File");
 
@@ -227,7 +228,7 @@ public class FileTest {
                 Content.of("loc", "typo", 0));
 
         final var actualUpdatedFile = assertDoesNotThrow(
-                () -> File.with(aFile).update(expectedFolder, expectedName, content));
+                () -> File.with(aFile).update(expectedActorId, expectedFolder, expectedName, content));
 
         assertEquals(expectedName, actualUpdatedFile.getName());
         assertEquals(expectedContentType, actualUpdatedFile.getContent().type());
@@ -244,6 +245,7 @@ public class FileTest {
         final var expectedCreator = MemberID.of(UUID.randomUUID());
         final var expectedOwner = MemberID.of(UUID.randomUUID());
         final var expectedFolder = Folder.createRoot(expectedOwner).getId();
+        final var expectedActorId = expectedOwner;
 
         final var expectedName = "";
 
@@ -259,7 +261,7 @@ public class FileTest {
         final var aFile = File.create(expectedCreator, expectedOwner, expectedFolder, FileName.of("file"), content);
 
         final var actualException = assertThrows(ValidationException.class,
-                () -> File.with(aFile).update(expectedFolder, FileName.of(expectedName), content));
+                () -> File.with(aFile).update(expectedActorId, expectedFolder, FileName.of(expectedName), content));
 
         assertEquals(expectedExceptionMessage, actualException.getMessage());
         assertEquals(expectedErrorsCount, actualException.getErrors().size());
@@ -272,6 +274,7 @@ public class FileTest {
         final var expectedCreator = MemberID.of(UUID.randomUUID());
         final var expectedOwner = MemberID.of(UUID.randomUUID());
         final var expectedFolder = Folder.createRoot(expectedOwner).getId();
+        final var expectedActorId = expectedOwner;
 
         final String expectedName = null;
 
@@ -287,7 +290,7 @@ public class FileTest {
         final var aFile = File.create(expectedCreator, expectedOwner, expectedFolder, FileName.of("file"), content);
 
         final var actualException = assertThrows(ValidationException.class,
-                () -> File.with(aFile).update(expectedFolder, FileName.of(expectedName), content));
+                () -> File.with(aFile).update(expectedActorId, expectedFolder, FileName.of(expectedName), content));
 
         assertEquals(expectedExceptionMessage, actualException.getMessage());
         assertEquals(expectedErrorsCount, actualException.getErrors().size());
@@ -301,6 +304,7 @@ public class FileTest {
         final var expectedCreator = MemberID.of(UUID.randomUUID());
         final var expectedOwner = MemberID.of(UUID.randomUUID());
         final var expectedFolder = Folder.createRoot(expectedOwner).getId();
+        final var expectedActorId = expectedOwner;
 
         final var expectedName = """
                 filefilefilefilefilefilefilefilefilefilefilefilefilefilefilefilefilefile
@@ -318,7 +322,7 @@ public class FileTest {
         final var aFile = File.create(expectedCreator, expectedOwner, expectedFolder, FileName.of("file"), content);
 
         final var actualException = assertThrows(ValidationException.class,
-                () -> File.with(aFile).update(expectedFolder, FileName.of(expectedName), content));
+                () -> File.with(aFile).update(expectedActorId, expectedFolder, FileName.of(expectedName), content));
 
         assertEquals(expectedExceptionMessage, actualException.getMessage());
         assertEquals(expectedErrorsCount, actualException.getErrors().size());
@@ -332,6 +336,7 @@ public class FileTest {
         final var expectedCreator = MemberID.of(UUID.randomUUID());
         final var expectedOwner = MemberID.of(UUID.randomUUID());
         final var expectedFolder = Folder.createRoot(expectedOwner).getId();
+        final var expectedActorId = expectedOwner;
 
         final var expectedName = "nul";
 
@@ -347,7 +352,7 @@ public class FileTest {
         final var aFile = File.create(expectedCreator, expectedOwner, expectedFolder, FileName.of("file"), content);
 
         final var actualException = assertThrows(ValidationException.class,
-                () -> File.with(aFile).update(expectedFolder, FileName.of(expectedName), content));
+                () -> File.with(aFile).update(expectedActorId, expectedFolder, FileName.of(expectedName), content));
 
         assertEquals(expectedExceptionMessage, actualException.getMessage());
         assertEquals(expectedErrorsCount, actualException.getErrors().size());

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/access/AclJpaGateway.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/access/AclJpaGateway.java
@@ -7,20 +7,31 @@ import org.springframework.stereotype.Component;
 import com.callv2.drive.domain.access.Acl;
 import com.callv2.drive.domain.access.AclGateway;
 import com.callv2.drive.domain.access.Resource;
+import com.callv2.drive.infrastructure.access.persistence.AclJpaEntity;
+import com.callv2.drive.infrastructure.access.persistence.AclJpaRepository;
 
 @Component
 public class AclJpaGateway implements AclGateway {
 
+    private final AclJpaRepository aclJpaRepository;
+
+    public AclJpaGateway(final AclJpaRepository aclJpaRepository) {
+        this.aclJpaRepository = aclJpaRepository;
+    }
+
     @Override
-    public Acl create(Acl acl) {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'create'");
+    public Acl create(final Acl acl) {
+        return aclJpaRepository.save(AclJpaEntity.fromDomain(acl)).toDomain();
     }
 
     @Override
     public Optional<Acl> findByResource(Resource<?> resource) {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'findByResource'");
+
+        return aclJpaRepository.findAll().stream()
+                .map(AclJpaEntity::toDomain)
+                .filter(acl -> acl.getResource().equals(resource))
+                .findFirst();
+
     }
 
 }

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/access/AclJpaGateway.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/access/AclJpaGateway.java
@@ -10,9 +10,12 @@ import org.springframework.transaction.annotation.Transactional;
 import com.callv2.drive.domain.access.Acl;
 import com.callv2.drive.domain.access.AclGateway;
 import com.callv2.drive.domain.access.Resource;
+import com.callv2.drive.domain.file.FileID;
 import com.callv2.drive.domain.folder.FolderID;
 import com.callv2.drive.infrastructure.access.persistence.AclJpaEntity;
 import com.callv2.drive.infrastructure.access.persistence.AclJpaRepository;
+import com.callv2.drive.infrastructure.access.persistence.FileAclJpaEntity;
+import com.callv2.drive.infrastructure.access.persistence.FileAclRepository;
 import com.callv2.drive.infrastructure.access.persistence.FolderAclJpaEntity;
 import com.callv2.drive.infrastructure.access.persistence.FolderAclRepository;
 
@@ -21,12 +24,15 @@ public class AclJpaGateway implements AclGateway {
 
     private final AclJpaRepository aclJpaRepository;
     private final FolderAclRepository folderAclRepository;
+    private final FileAclRepository fileAclRepository;
 
     public AclJpaGateway(
             final AclJpaRepository aclJpaRepository,
-            final FolderAclRepository folderAclRepository) {
+            final FolderAclRepository folderAclRepository,
+            final FileAclRepository fileAclRepository) {
         this.aclJpaRepository = aclJpaRepository;
         this.folderAclRepository = folderAclRepository;
+        this.fileAclRepository = fileAclRepository;
     }
 
     @Override
@@ -54,8 +60,7 @@ public class AclJpaGateway implements AclGateway {
     private Acl save(final Acl acl) {
         switch (acl.getResource().type()) {
             case FOLDER -> saveFolderAcl(acl);
-            case FILE -> {
-            }
+            case FILE -> saveFileAcl(acl);
         }
 
         return aclJpaRepository.save(AclJpaEntity.fromDomain(acl)).toDomain();
@@ -69,6 +74,18 @@ public class AclJpaGateway implements AclGateway {
         this.folderAclRepository.saveAll(Stream
                 .concat(acl.getDirectEntries().stream(), acl.getInheritedEntries().stream())
                 .map(entry -> FolderAclJpaEntity.from(resource, entry))
+                .collect(Collectors.toSet()));
+
+    }
+
+    private void saveFileAcl(final Acl acl) {
+
+        final Resource<FileID> resource = Resource
+                .file(FileID.fromStringValue(acl.getResource().id().getStringValue()));
+
+        this.fileAclRepository.saveAll(Stream
+                .concat(acl.getDirectEntries().stream(), acl.getInheritedEntries().stream())
+                .map(entry -> FileAclJpaEntity.from(resource, entry))
                 .collect(Collectors.toSet()));
 
     }

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/access/AclJpaGateway.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/access/AclJpaGateway.java
@@ -20,7 +20,6 @@ import com.callv2.drive.infrastructure.access.persistence.FolderAclRepository;
 public class AclJpaGateway implements AclGateway {
 
     private final AclJpaRepository aclJpaRepository;
-
     private final FolderAclRepository folderAclRepository;
 
     public AclJpaGateway(
@@ -32,14 +31,12 @@ public class AclJpaGateway implements AclGateway {
 
     @Override
     public Acl create(final Acl acl) {
+        return save(acl);
+    }
 
-        switch (acl.getResource().type()) {
-            case FOLDER -> saveFolderAcl(acl);
-            case FILE -> {
-            }
-        }
-
-        return aclJpaRepository.save(AclJpaEntity.fromDomain(acl)).toDomain();
+    @Override
+    public Acl update(Acl acl) {
+        return save(acl);
     }
 
     @Transactional(readOnly = true)
@@ -54,14 +51,26 @@ public class AclJpaGateway implements AclGateway {
 
     }
 
+    private Acl save(final Acl acl) {
+        switch (acl.getResource().type()) {
+            case FOLDER -> saveFolderAcl(acl);
+            case FILE -> {
+            }
+        }
+
+        return aclJpaRepository.save(AclJpaEntity.fromDomain(acl)).toDomain();
+    }
+
     private void saveFolderAcl(final Acl acl) {
+
         final Resource<FolderID> resource = Resource
                 .folder(FolderID.fromStringValue(acl.getResource().id().getStringValue()));
 
-        Stream
+        this.folderAclRepository.saveAll(Stream
                 .concat(acl.getDirectEntries().stream(), acl.getInheritedEntries().stream())
-                .collect(Collectors.toSet())
-                .forEach(entry -> folderAclRepository.save(FolderAclJpaEntity.from(resource, entry)));
+                .map(entry -> FolderAclJpaEntity.from(resource, entry))
+                .collect(Collectors.toSet()));
+
     }
 
 }

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/access/AclJpaGateway.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/access/AclJpaGateway.java
@@ -1,37 +1,67 @@
 package com.callv2.drive.infrastructure.access;
 
 import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.callv2.drive.domain.access.Acl;
 import com.callv2.drive.domain.access.AclGateway;
 import com.callv2.drive.domain.access.Resource;
+import com.callv2.drive.domain.folder.FolderID;
 import com.callv2.drive.infrastructure.access.persistence.AclJpaEntity;
 import com.callv2.drive.infrastructure.access.persistence.AclJpaRepository;
+import com.callv2.drive.infrastructure.access.persistence.FolderAclJpaEntity;
+import com.callv2.drive.infrastructure.access.persistence.FolderAclRepository;
 
 @Component
 public class AclJpaGateway implements AclGateway {
 
     private final AclJpaRepository aclJpaRepository;
 
-    public AclJpaGateway(final AclJpaRepository aclJpaRepository) {
+    private final FolderAclRepository folderAclRepository;
+
+    public AclJpaGateway(
+            final AclJpaRepository aclJpaRepository,
+            final FolderAclRepository folderAclRepository) {
         this.aclJpaRepository = aclJpaRepository;
+        this.folderAclRepository = folderAclRepository;
     }
 
     @Override
     public Acl create(final Acl acl) {
+
+        switch (acl.getResource().type()) {
+            case FOLDER -> saveFolderAcl(acl);
+            case FILE -> {
+            }
+        }
+
         return aclJpaRepository.save(AclJpaEntity.fromDomain(acl)).toDomain();
     }
 
+    @Transactional(readOnly = true)
     @Override
     public Optional<Acl> findByResource(Resource<?> resource) {
 
-        return aclJpaRepository.findAll().stream()
+        return aclJpaRepository.findAll()
+                .stream()
                 .map(AclJpaEntity::toDomain)
                 .filter(acl -> acl.getResource().equals(resource))
                 .findFirst();
 
+    }
+
+    private void saveFolderAcl(final Acl acl) {
+        final Resource<FolderID> resource = Resource
+                .folder(FolderID.fromStringValue(acl.getResource().id().getStringValue()));
+
+        Stream
+                .concat(acl.getDirectEntries().stream(), acl.getInheritedEntries().stream())
+                .collect(Collectors.toSet())
+                .forEach(entry -> folderAclRepository.save(FolderAclJpaEntity.from(resource, entry)));
     }
 
 }

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/access/AclJpaGateway.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/access/AclJpaGateway.java
@@ -1,0 +1,26 @@
+package com.callv2.drive.infrastructure.access;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Component;
+
+import com.callv2.drive.domain.access.Acl;
+import com.callv2.drive.domain.access.AclGateway;
+import com.callv2.drive.domain.access.Resource;
+
+@Component
+public class AclJpaGateway implements AclGateway {
+
+    @Override
+    public Acl create(Acl acl) {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'create'");
+    }
+
+    @Override
+    public Optional<Acl> findByResource(Resource<?> resource) {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'findByResource'");
+    }
+
+}

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/access/model/UpdateAclMessage.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/access/model/UpdateAclMessage.java
@@ -1,0 +1,32 @@
+package com.callv2.drive.infrastructure.access.model;
+
+import java.io.Serializable;
+import java.time.Instant;
+import java.util.Set;
+import java.util.UUID;
+
+import com.callv2.drive.domain.access.AccessPermission;
+import com.callv2.drive.domain.access.ResourceType;
+import com.callv2.drive.domain.access.SharePermission;
+
+public record UpdateAclMessage(Data data) implements Serializable {
+
+    public record Data(
+            UUID aclId,
+            String resourceId,
+            ResourceType resourceType,
+            Set<Data.Entry> directEntries,
+            Set<Data.Entry> inheritedEntries,
+            Instant creadtedAt,
+            Instant updatedAt) implements Serializable {
+
+        public record Entry(
+                UUID memberId,
+                AccessPermission accessPermission,
+                SharePermission sharePermission,
+                Instant grantedAt) implements Serializable {
+
+        }
+
+    }
+}

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/access/persistence/AclJpaEntity.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/access/persistence/AclJpaEntity.java
@@ -1,0 +1,140 @@
+package com.callv2.drive.infrastructure.access.persistence;
+
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+import com.callv2.drive.domain.access.Acl;
+import com.callv2.drive.domain.access.ResourceType;
+
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Table;
+
+@Entity(name = "Acl")
+@Table(name = "acls")
+public class AclJpaEntity {
+
+    @Id
+    private UUID id;
+
+    private String resourceId;
+
+    @Enumerated(EnumType.STRING)
+    private ResourceType resourceType;
+
+    @ElementCollection
+    @CollectionTable(name = "acl_direct_entries", joinColumns = @JoinColumn(name = "acl_id"))
+    private Set<EntryJpa> directEntries = new HashSet<>();
+
+    @ElementCollection
+    @CollectionTable(name = "acl_inherited_entries", joinColumns = @JoinColumn(name = "acl_id"))
+    private Set<EntryJpa> inheritedEntries = new HashSet<>();
+
+    private Instant createdAt;
+
+    private Instant updatedAt;
+
+    public AclJpaEntity() {
+    }
+
+    private AclJpaEntity(
+            final UUID id,
+            final String resourceId,
+            final ResourceType resourceType,
+            final Set<EntryJpa> directEntries,
+            final Set<EntryJpa> inheritedEntries,
+            final Instant createdAt,
+            final Instant updatedAt) {
+        this.id = id;
+        this.resourceId = resourceId;
+        this.resourceType = resourceType;
+        this.directEntries = directEntries;
+        this.inheritedEntries = inheritedEntries;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    public static AclJpaEntity fromDomain(final Acl acl) {
+
+        final var directEntries = acl.getDirectEntries().stream()
+                .map(EntryJpa::fromDomain)
+                .collect(java.util.stream.Collectors.toSet());
+
+        final var inheritedEntries = acl.getInheritedEntries().stream()
+                .map(EntryJpa::fromDomain)
+                .collect(java.util.stream.Collectors.toSet());
+
+        return new AclJpaEntity(
+                acl.getId().getValue(),
+                acl.getResource().id().getStringValue(),
+                acl.getResource().type(),
+                directEntries,
+                inheritedEntries,
+                acl.getCreatedAt(),
+                acl.getUpdatedAt());
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public String getResourceId() {
+        return resourceId;
+    }
+
+    public void setResourceId(String resourceId) {
+        this.resourceId = resourceId;
+    }
+
+    public ResourceType getResourceType() {
+        return resourceType;
+    }
+
+    public void setResourceType(ResourceType resourceType) {
+        this.resourceType = resourceType;
+    }
+
+    public Set<EntryJpa> getDirectEntries() {
+        return directEntries;
+    }
+
+    public void setDirectEntries(Set<EntryJpa> directEntries) {
+        this.directEntries = directEntries;
+    }
+
+    public Set<EntryJpa> getInheritedEntries() {
+        return inheritedEntries;
+    }
+
+    public void setInheritedEntries(Set<EntryJpa> inheritedEntries) {
+        this.inheritedEntries = inheritedEntries;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(Instant updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+}

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/access/persistence/AclJpaEntity.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/access/persistence/AclJpaEntity.java
@@ -6,7 +6,12 @@ import java.util.Set;
 import java.util.UUID;
 
 import com.callv2.drive.domain.access.Acl;
+import com.callv2.drive.domain.access.AclID;
+import com.callv2.drive.domain.access.Entry;
+import com.callv2.drive.domain.access.Resource;
 import com.callv2.drive.domain.access.ResourceType;
+import com.callv2.drive.domain.file.FileID;
+import com.callv2.drive.domain.folder.FolderID;
 
 import jakarta.persistence.CollectionTable;
 import jakarta.persistence.ElementCollection;
@@ -63,11 +68,11 @@ public class AclJpaEntity {
 
     public static AclJpaEntity fromDomain(final Acl acl) {
 
-        final var directEntries = acl.getDirectEntries().stream()
+        final Set<EntryJpa> directEntries = acl.getDirectEntries().stream()
                 .map(EntryJpa::fromDomain)
                 .collect(java.util.stream.Collectors.toSet());
 
-        final var inheritedEntries = acl.getInheritedEntries().stream()
+        final Set<EntryJpa> inheritedEntries = acl.getInheritedEntries().stream()
                 .map(EntryJpa::fromDomain)
                 .collect(java.util.stream.Collectors.toSet());
 
@@ -79,6 +84,31 @@ public class AclJpaEntity {
                 inheritedEntries,
                 acl.getCreatedAt(),
                 acl.getUpdatedAt());
+    }
+
+    public Acl toDomain() {
+
+        final Set<Entry> directEntries = this.directEntries.stream()
+                .map(EntryJpa::toDomain)
+                .collect(java.util.stream.Collectors.toSet());
+
+        final Set<Entry> inheritedEntries = this.inheritedEntries.stream()
+                .map(EntryJpa::toDomain)
+                .collect(java.util.stream.Collectors.toSet());
+
+        final Resource<?> resource = switch (this.resourceType) {
+            case FILE -> Resource.file(FileID.of(UUID.fromString(this.resourceId)));
+            case FOLDER -> Resource.folder(FolderID.of(UUID.fromString(this.resourceId)));
+            default -> throw new IllegalStateException("Unexpected value: " + this.resourceId);
+        };
+
+        return Acl.with(
+                AclID.of(this.id),
+                resource,
+                directEntries,
+                inheritedEntries,
+                this.createdAt,
+                this.updatedAt);
     }
 
     public UUID getId() {

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/access/persistence/AclJpaRepository.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/access/persistence/AclJpaRepository.java
@@ -1,0 +1,9 @@
+package com.callv2.drive.infrastructure.access.persistence;
+
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AclJpaRepository extends JpaRepository<AclJpaEntity, UUID> {
+
+}

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/access/persistence/EntryJpa.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/access/persistence/EntryJpa.java
@@ -1,0 +1,64 @@
+package com.callv2.drive.infrastructure.access.persistence;
+
+import java.io.Serializable;
+import java.time.Instant;
+import java.util.UUID;
+
+import com.callv2.drive.domain.access.AccessPermission;
+import com.callv2.drive.domain.access.Entry;
+import com.callv2.drive.domain.access.SharePermission;
+import com.callv2.drive.domain.member.MemberID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+
+@Embeddable
+public class EntryJpa implements Serializable {
+
+    @Column(name = "member_id")
+    private UUID memberId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "access_permission")
+    private AccessPermission accessPermission;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "share_permission")
+    private SharePermission sharePermission;
+
+    @Column(name = "granted_at")
+    private Instant grantedAt;
+
+    public EntryJpa() {
+    }
+
+    private EntryJpa(
+            final UUID memberId,
+            final AccessPermission accessPermission,
+            final SharePermission sharePermission,
+            final Instant grantedAt) {
+        this.memberId = memberId;
+        this.accessPermission = accessPermission;
+        this.sharePermission = sharePermission;
+        this.grantedAt = grantedAt;
+    }
+
+    public static EntryJpa fromDomain(final Entry entry) {
+        return new EntryJpa(
+                entry.member().getValue(),
+                entry.accessPermission(),
+                entry.sharePermission(),
+                entry.grantedAt());
+    }
+
+    public Entry toDomain() {
+        return new Entry(
+                MemberID.of(memberId),
+                accessPermission,
+                sharePermission,
+                grantedAt);
+    }
+
+}

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/access/persistence/FileAclID.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/access/persistence/FileAclID.java
@@ -1,0 +1,74 @@
+package com.callv2.drive.infrastructure.access.persistence;
+
+import java.io.Serializable;
+import java.util.Objects;
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+public class FileAclID implements Serializable {
+
+    @Column(name = "file_id", nullable = false)
+    private UUID fileId;
+
+    @Column(name = "member_id", nullable = false)
+    private UUID memberId;
+
+    public FileAclID() {
+    }
+
+    private FileAclID(UUID fileId, UUID memberId) {
+        this.fileId = fileId;
+        this.memberId = memberId;
+    }
+
+    public static FileAclID from(final UUID fileId, final UUID memberId) {
+        return new FileAclID(fileId, memberId);
+    }
+
+    public UUID getFileId() {
+        return fileId;
+    }
+
+    public void setFileId(UUID fileId) {
+        this.fileId = fileId;
+    }
+
+    public UUID getMemberId() {
+        return memberId;
+    }
+
+    public void setMemberId(UUID memberId) {
+        this.memberId = memberId;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(fileId, memberId);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        FileAclID other = (FileAclID) obj;
+        if (fileId == null) {
+            if (other.fileId != null)
+                return false;
+        } else if (!fileId.equals(other.fileId))
+            return false;
+        if (memberId == null) {
+            if (other.memberId != null)
+                return false;
+        } else if (!memberId.equals(other.memberId))
+            return false;
+        return true;
+    }
+
+}

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/access/persistence/FileAclJpaEntity.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/access/persistence/FileAclJpaEntity.java
@@ -1,0 +1,71 @@
+package com.callv2.drive.infrastructure.access.persistence;
+
+import com.callv2.drive.domain.access.AccessPermission;
+import com.callv2.drive.domain.access.Entry;
+import com.callv2.drive.domain.access.Resource;
+import com.callv2.drive.domain.access.SharePermission;
+import com.callv2.drive.domain.file.FileID;
+
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+
+@Entity(name = "FileAcl")
+@Table(name = "file_acls")
+public class FileAclJpaEntity {
+
+    @EmbeddedId
+    private FileAclID id;
+
+    @Enumerated(EnumType.STRING)
+    private AccessPermission effectiveAccessPermission;
+
+    @Enumerated(EnumType.STRING)
+    private SharePermission effectiveSharePermission;
+
+    public FileAclJpaEntity() {
+    }
+
+    private FileAclJpaEntity(
+            final FileAclID id,
+            final AccessPermission effectiveAccessPermission,
+            final SharePermission effectiveSharePermission) {
+        this.id = id;
+        this.effectiveAccessPermission = effectiveAccessPermission;
+        this.effectiveSharePermission = effectiveSharePermission;
+    }
+
+    public static FileAclJpaEntity from(Resource<FileID> resource, Entry entry) {
+        return new FileAclJpaEntity(
+                FileAclID.from(resource.id().getValue(), entry.member().getValue()),
+                entry.accessPermission(),
+                entry.sharePermission());
+    }
+
+    public FileAclID getId() {
+        return id;
+    }
+
+    public void setId(FileAclID id) {
+        this.id = id;
+    }
+
+    public AccessPermission getEffectiveAccessPermission() {
+        return effectiveAccessPermission;
+    }
+
+    public void setEffectiveAccessPermission(AccessPermission effectiveAccessPermission) {
+        this.effectiveAccessPermission = effectiveAccessPermission;
+    }
+
+    public SharePermission getEffectiveSharePermission() {
+        return effectiveSharePermission;
+    }
+
+    public void setEffectiveSharePermission(SharePermission effectiveSharePermission) {
+        this.effectiveSharePermission = effectiveSharePermission;
+    }
+
+}

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/access/persistence/FileAclRepository.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/access/persistence/FileAclRepository.java
@@ -1,0 +1,7 @@
+package com.callv2.drive.infrastructure.access.persistence;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FileAclRepository extends JpaRepository<FileAclJpaEntity, FileAclID> {
+
+}

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/access/persistence/FolderAclID.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/access/persistence/FolderAclID.java
@@ -1,0 +1,74 @@
+package com.callv2.drive.infrastructure.access.persistence;
+
+import java.io.Serializable;
+import java.util.Objects;
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+public class FolderAclID implements Serializable {
+
+    @Column(name = "folder_id", nullable = false)
+    private UUID folderId;
+
+    @Column(name = "member_id", nullable = false)
+    private UUID memberId;
+
+    public FolderAclID() {
+    }
+
+    private FolderAclID(UUID folderId, UUID memberId) {
+        this.folderId = folderId;
+        this.memberId = memberId;
+    }
+
+    public static FolderAclID from(final UUID folderId, final UUID memberId) {
+        return new FolderAclID(folderId, memberId);
+    }
+
+    public UUID getFolderId() {
+        return folderId;
+    }
+
+    public void setFolderId(UUID folderId) {
+        this.folderId = folderId;
+    }
+
+    public UUID getMemberId() {
+        return memberId;
+    }
+
+    public void setMemberId(UUID memberId) {
+        this.memberId = memberId;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(folderId, memberId);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        FolderAclID other = (FolderAclID) obj;
+        if (folderId == null) {
+            if (other.folderId != null)
+                return false;
+        } else if (!folderId.equals(other.folderId))
+            return false;
+        if (memberId == null) {
+            if (other.memberId != null)
+                return false;
+        } else if (!memberId.equals(other.memberId))
+            return false;
+        return true;
+    }
+
+}

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/access/persistence/FolderAclJpaEntity.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/access/persistence/FolderAclJpaEntity.java
@@ -1,0 +1,71 @@
+package com.callv2.drive.infrastructure.access.persistence;
+
+import com.callv2.drive.domain.access.AccessPermission;
+import com.callv2.drive.domain.access.Entry;
+import com.callv2.drive.domain.access.Resource;
+import com.callv2.drive.domain.access.SharePermission;
+import com.callv2.drive.domain.folder.FolderID;
+
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+
+@Entity(name = "FolderAcl")
+@Table(name = "folder_acls")
+public class FolderAclJpaEntity {
+
+    @EmbeddedId
+    private FolderAclID id;
+
+    @Enumerated(EnumType.STRING)
+    private AccessPermission effectiveAccessPermission;
+
+    @Enumerated(EnumType.STRING)
+    private SharePermission effectiveSharePermission;
+
+    public FolderAclJpaEntity() {
+    }
+
+    private FolderAclJpaEntity(
+            final FolderAclID id,
+            final AccessPermission effectiveAccessPermission,
+            final SharePermission effectiveSharePermission) {
+        this.id = id;
+        this.effectiveAccessPermission = effectiveAccessPermission;
+        this.effectiveSharePermission = effectiveSharePermission;
+    }
+
+    public static FolderAclJpaEntity from(Resource<FolderID> resource, Entry entry) {
+        return new FolderAclJpaEntity(
+                FolderAclID.from(resource.id().getValue(), entry.member().getValue()),
+                entry.accessPermission(),
+                entry.sharePermission());
+    }
+
+    public FolderAclID getId() {
+        return id;
+    }
+
+    public void setId(FolderAclID id) {
+        this.id = id;
+    }
+
+    public AccessPermission getEffectiveAccessPermission() {
+        return effectiveAccessPermission;
+    }
+
+    public void setEffectiveAccessPermission(AccessPermission effectiveAccessPermission) {
+        this.effectiveAccessPermission = effectiveAccessPermission;
+    }
+
+    public SharePermission getEffectiveSharePermission() {
+        return effectiveSharePermission;
+    }
+
+    public void setEffectiveSharePermission(SharePermission effectiveSharePermission) {
+        this.effectiveSharePermission = effectiveSharePermission;
+    }
+
+}

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/access/persistence/FolderAclRepository.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/access/persistence/FolderAclRepository.java
@@ -1,0 +1,7 @@
+package com.callv2.drive.infrastructure.access.persistence;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FolderAclRepository extends JpaRepository<FolderAclJpaEntity, FolderAclID> {
+
+}

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/api/MemberAdminAPI.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/api/MemberAdminAPI.java
@@ -1,6 +1,7 @@
 package com.callv2.drive.infrastructure.api;
 
 import java.util.List;
+import java.util.UUID;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -33,14 +34,14 @@ public interface MemberAdminAPI {
     @ApiResponse(responseCode = "200", description = "Retrieve successfuly")
     @ApiResponse(responseCode = "404", description = "Member not found", content = @Content(schema = @Schema(implementation = Void.class)))
     @GetMapping("{id}/quotas")
-    ResponseEntity<MemberQuotaResponse> getQuota(@PathVariable("id") String id);
+    ResponseEntity<MemberQuotaResponse> getQuota(@PathVariable("id") UUID id);
 
     @Operation(summary = "Approve drive quota request", description = "This method approve a drive amount quota request", security = @SecurityRequirement(name = "bearerAuth"))
     @ApiResponse(responseCode = "204", description = "Approved successfuly")
     @ApiResponse(responseCode = "404", description = "Member not found", content = @Content(schema = @Schema(implementation = Void.class)))
     @PatchMapping("{id}/quotas/requests")
     ResponseEntity<Void> approveQuotaRequest(
-            @PathVariable("id") String id,
+            @PathVariable("id") UUID id,
             @RequestParam(value = "approved", defaultValue = "true") boolean approved);
 
     @Operation(summary = "List quotas requests", description = "This method list quotas requests", security = @SecurityRequirement(name = "bearerAuth"))

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/api/controller/FileController.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/api/controller/FileController.java
@@ -60,7 +60,7 @@ public class FileController implements FileAPI {
     @Override
     public ResponseEntity<CreateFileResponse> create(UUID folderId, MultipartFile file) {
 
-        final var ownerId = SecurityContext.getAuthenticatedUser();
+        final var ownerId = SecurityContext.getAuthenticatedUserId();
 
         final var response = FilePresenter
                 .present(createFileUseCase.execute(FileAdapter.adapt(ownerId, folderId, file)));
@@ -72,7 +72,7 @@ public class FileController implements FileAPI {
 
     @Override
     public ResponseEntity<Void> delete(UUID id) {
-        final var deleterId = SecurityContext.getAuthenticatedUser();
+        final var deleterId = SecurityContext.getAuthenticatedUserId();
 
         DeleteFileInput deleteFileInput = DeleteFileInput.of(deleterId, id);
 

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/api/controller/FileController.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/api/controller/FileController.java
@@ -21,6 +21,7 @@ import com.callv2.drive.application.file.delete.DeleteFileInput;
 import com.callv2.drive.application.file.delete.DeleteFileUseCase;
 import com.callv2.drive.application.file.retrieve.get.GetFileInput;
 import com.callv2.drive.application.file.retrieve.get.GetFileUseCase;
+import com.callv2.drive.application.file.retrieve.list.FileListInput;
 import com.callv2.drive.application.file.retrieve.list.ListFilesUseCase;
 import com.callv2.drive.domain.pagination.Filter;
 import com.callv2.drive.domain.pagination.Page;
@@ -118,7 +119,10 @@ public class FileController implements FileAPI {
                 filterOperator,
                 searchFilters);
 
-        return ResponseEntity.ok(listFilesUseCase.execute(query).map(FilePresenter::present));
+        final var actorId = SecurityContext.getAuthenticatedUserId();
+
+        return ResponseEntity
+                .ok(listFilesUseCase.execute(new FileListInput(actorId, query)).map(FilePresenter::present));
     }
 
 }

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/api/controller/FileController.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/api/controller/FileController.java
@@ -83,14 +83,19 @@ public class FileController implements FileAPI {
 
     @Override
     public ResponseEntity<GetFileResponse> getById(UUID id) {
-        return ResponseEntity.ok(FilePresenter.present(getFileUseCase.execute(GetFileInput.from(id))));
+
+        final var actorId = SecurityContext.getAuthenticatedUserId();
+
+        return ResponseEntity.ok(FilePresenter.present(getFileUseCase.execute(GetFileInput.from(id, actorId))));
     }
 
     @Override
     @Async
     public ResponseEntity<Resource> download(UUID id) {
 
-        final GetFileContentOutput output = getFileContentUseCase.execute(GetFileContentInput.with(id));
+        final var actorId = SecurityContext.getAuthenticatedUserId();
+
+        final GetFileContentOutput output = getFileContentUseCase.execute(GetFileContentInput.with(id, actorId));
 
         return ResponseEntity.ok()
                 .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + output.name() + "\"")

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/api/controller/FolderController.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/api/controller/FolderController.java
@@ -16,6 +16,7 @@ import com.callv2.drive.application.folder.move.MoveFolderUseCase;
 import com.callv2.drive.application.folder.retrieve.get.GetFolderUseCase;
 import com.callv2.drive.application.folder.retrieve.get.root.GetRootFolderInput;
 import com.callv2.drive.application.folder.retrieve.get.root.GetRootFolderUseCase;
+import com.callv2.drive.application.folder.retrieve.list.FolderListInput;
 import com.callv2.drive.application.folder.retrieve.list.ListFoldersUseCase;
 import com.callv2.drive.application.folder.update.name.UpdateFolderNameInput;
 import com.callv2.drive.application.folder.update.name.UpdateFolderNameUseCase;
@@ -81,13 +82,17 @@ public class FolderController implements FolderAPI {
 
     @Override
     public ResponseEntity<GetFolderResponse> getById(final UUID id) {
+
+        final var actorId = SecurityContext.getAuthenticatedUserId();
+
         return ResponseEntity
-                .ok(FolderPresenter.present(getFolderUseCase.execute(FolderAdapter.adapt(id))));
+                .ok(FolderPresenter.present(getFolderUseCase.execute(FolderAdapter.adapt(id, actorId))));
     }
 
     @Override
     public ResponseEntity<Void> move(final UUID id, final MoveFolderRequest request) {
-        moveFolderUseCase.execute(MoveFolderInput.with(id, request.newParentId()));
+        final var actorId = SecurityContext.getAuthenticatedUserId();
+        moveFolderUseCase.execute(MoveFolderInput.with(id, request.newParentId(), actorId));
         return ResponseEntity.noContent().build();
     }
 
@@ -111,13 +116,18 @@ public class FolderController implements FolderAPI {
                 filterOperator,
                 searchFilters);
 
-        return ResponseEntity.ok(listFoldersUseCase.execute(query).map(FolderPresenter::present));
+        final var actorId = SecurityContext.getAuthenticatedUserId();
+
+        return ResponseEntity
+                .ok(listFoldersUseCase.execute(new FolderListInput(actorId, query)).map(FolderPresenter::present));
     }
 
     @Override
     public ResponseEntity<Void> changeName(UUID id, String newName) {
 
-        this.updateFolderNameUseCase.execute(new UpdateFolderNameInput(id, newName));
+        final var actorId = SecurityContext.getAuthenticatedUserId();
+
+        this.updateFolderNameUseCase.execute(new UpdateFolderNameInput(id, newName, actorId));
 
         return ResponseEntity.noContent().build();
     }

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/api/controller/FolderController.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/api/controller/FolderController.java
@@ -65,12 +65,12 @@ public class FolderController implements FolderAPI {
     @Override
     public ResponseEntity<GetFolderResponse> getRoot() {
         return ResponseEntity.ok(FolderPresenter.present(
-                getRootFolderUseCase.execute(GetRootFolderInput.from(SecurityContext.getAuthenticatedUser()))));
+                getRootFolderUseCase.execute(GetRootFolderInput.from(SecurityContext.getAuthenticatedUserId()))));
     }
 
     @Override
     public ResponseEntity<CreateFolderResponse> create(final CreateFolderRequest request) {
-        final String ownerId = SecurityContext.getAuthenticatedUser();
+        final UUID ownerId = SecurityContext.getAuthenticatedUserId();
         final var response = FolderPresenter
                 .present(createFolderUseCase.execute(FolderAdapter.adapt(request, ownerId)));
 
@@ -126,7 +126,7 @@ public class FolderController implements FolderAPI {
     @Override
     public ResponseEntity<Void> delete(UUID id) {
 
-        final var memberId = SecurityContext.getAuthenticatedUser();
+        final var memberId = SecurityContext.getAuthenticatedUserId();
 
         this.deleteFolderUseCase.execute(new DeleteFolderInput(id, memberId));
 

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/api/controller/MemberAdminController.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/api/controller/MemberAdminController.java
@@ -1,6 +1,7 @@
 package com.callv2.drive.infrastructure.api.controller;
 
 import java.util.List;
+import java.util.UUID;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -49,12 +50,12 @@ public class MemberAdminController implements MemberAdminAPI {
     }
 
     @Override
-    public ResponseEntity<MemberQuotaResponse> getQuota(String id) {
+    public ResponseEntity<MemberQuotaResponse> getQuota(UUID id) {
         return ResponseEntity.ok(MemberPresenter.present(getQuotaUseCase.execute(GetQuotaInput.of(id))));
     }
 
     @Override
-    public ResponseEntity<Void> approveQuotaRequest(final String id, final boolean approved) {
+    public ResponseEntity<Void> approveQuotaRequest(final UUID id, final boolean approved) {
         this.approveRequestQuotaUseCase.execute(ApproveRequestQuotaInput.of(id, approved));
         return ResponseEntity.noContent().build();
     }

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/api/controller/MemberController.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/api/controller/MemberController.java
@@ -1,5 +1,7 @@
 package com.callv2.drive.infrastructure.api.controller;
 
+import java.util.UUID;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 
@@ -29,7 +31,7 @@ public class MemberController implements MemberAPI {
     @Override
     public ResponseEntity<Void> requestQuota(final long amount, final QuotaUnit unit) {
 
-        final String memberId = SecurityContext.getAuthenticatedUser();
+        final UUID memberId = SecurityContext.getAuthenticatedUserId();
 
         this.createRequestQuotaUseCase.execute(CreateRequestQuotaInput.of(memberId, amount, unit));
 
@@ -40,7 +42,7 @@ public class MemberController implements MemberAPI {
     public ResponseEntity<MemberQuotaResponse> getQuota() {
         return ResponseEntity
                 .ok(MemberPresenter.present(
-                        this.getQuotaUseCase.execute(GetQuotaInput.of(SecurityContext.getAuthenticatedUser()))));
+                        this.getQuotaUseCase.execute(GetQuotaInput.of(SecurityContext.getAuthenticatedUserId()))));
     }
 
 }

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/configuration/StorageConfig.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/configuration/StorageConfig.java
@@ -6,20 +6,16 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import com.callv2.drive.domain.storage.StorageService;
 import com.callv2.drive.infrastructure.configuration.properties.storage.FileSystemStorageProperties;
-import com.callv2.drive.infrastructure.storage.FileSystemStorageService;
+import com.callv2.drive.infrastructure.storage.FileSystemStorage;
 
 @Configuration
 public class StorageConfig {
 
     @Bean
-    StorageService storageService(final FileSystemStorageProperties properties) {
-
+    FileSystemStorage fileSystemStorage(final FileSystemStorageProperties properties) {
         final Path location = Path.of(properties.getLocation());
-
-        return new FileSystemStorageService(location);
-
+        return new FileSystemStorage(location);
     }
 
     @Bean

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/configuration/usecase/FileUseCaseConfig.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/configuration/usecase/FileUseCaseConfig.java
@@ -54,6 +54,7 @@ public class FileUseCaseConfig {
     @Bean
     CreateFileUseCase createFileUseCase() {
         return new DefaultCreateFileUseCase(
+                eventDispatcher,
                 memberGateway,
                 folderGateway,
                 fileGateway,

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/configuration/usecase/FileUseCaseConfig.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/configuration/usecase/FileUseCaseConfig.java
@@ -15,37 +15,51 @@ import com.callv2.drive.application.file.retrieve.get.DefaultGetFileUseCase;
 import com.callv2.drive.application.file.retrieve.get.GetFileUseCase;
 import com.callv2.drive.application.file.retrieve.list.DefaultListFilesUseCase;
 import com.callv2.drive.application.file.retrieve.list.ListFilesUseCase;
+import com.callv2.drive.domain.access.AclGateway;
 import com.callv2.drive.domain.event.EventDispatcher;
 import com.callv2.drive.domain.file.FileGateway;
 import com.callv2.drive.domain.folder.FolderGateway;
 import com.callv2.drive.domain.member.MemberGateway;
-import com.callv2.drive.domain.storage.StorageService;
+import com.callv2.drive.domain.storage.StorageGateway;
+import com.callv2.drive.domain.storage.StorageKeyGenerator;
 
 @Configuration
 public class FileUseCaseConfig {
 
+    private final AclGateway aclGateway;
     private final MemberGateway memberGateway;
     private final FolderGateway folderGateway;
     private final FileGateway fileGateway;
-    private final StorageService storageService;
+    private final StorageKeyGenerator storageKeyGenerator;
+    private final StorageGateway storageGateway;
     private final EventDispatcher eventDispatcher;
 
     public FileUseCaseConfig(
+            final AclGateway aclGateway,
             final MemberGateway memberGateway,
             final FolderGateway folderGateway,
             final FileGateway fileGateway,
-            final StorageService storageService,
+            final StorageKeyGenerator storageKeyGenerator,
+            final StorageGateway storageService,
             final EventDispatcher eventDispatcher) {
+        this.aclGateway = aclGateway;
         this.memberGateway = memberGateway;
         this.folderGateway = folderGateway;
         this.fileGateway = fileGateway;
-        this.storageService = storageService;
+        this.storageKeyGenerator = storageKeyGenerator;
+        this.storageGateway = storageService;
         this.eventDispatcher = eventDispatcher;
     }
 
     @Bean
     CreateFileUseCase createFileUseCase() {
-        return new DefaultCreateFileUseCase(memberGateway, folderGateway, fileGateway, storageService);
+        return new DefaultCreateFileUseCase(
+                memberGateway,
+                folderGateway,
+                fileGateway,
+                storageKeyGenerator,
+                storageGateway,
+                aclGateway);
     }
 
     @Bean
@@ -60,7 +74,7 @@ public class FileUseCaseConfig {
 
     @Bean
     GetFileContentUseCase getFileContentUseCase() {
-        return new DefaultGetFileContentUseCase(fileGateway, storageService);
+        return new DefaultGetFileContentUseCase(fileGateway, storageGateway);
     }
 
     @Bean
@@ -70,6 +84,6 @@ public class FileUseCaseConfig {
 
     @Bean
     DeleteFileContentUseCase deleteFileContentUseCase() {
-        return new DefaultlDeleteFileContentUseCase(fileGateway, storageService);
+        return new DefaultlDeleteFileContentUseCase(fileGateway, storageGateway);
     }
 }

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/configuration/usecase/FolderUseCaseConfig.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/configuration/usecase/FolderUseCaseConfig.java
@@ -52,7 +52,7 @@ public class FolderUseCaseConfig {
 
     @Bean
     CreateFolderUseCase createFolderUseCase() {
-        return new DefaultCreateFolderUseCase(memberGateway, folderGateway);
+        return new DefaultCreateFolderUseCase(eventDispatcher, aclGateway, memberGateway, folderGateway);
     }
 
     @Bean

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/configuration/usecase/FolderUseCaseConfig.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/configuration/usecase/FolderUseCaseConfig.java
@@ -57,7 +57,7 @@ public class FolderUseCaseConfig {
 
     @Bean
     GetFolderUseCase getFolderUseCase() {
-        return new DefaultGetFolderUseCase(aclGateway, folderGateway, fileGateway);
+        return new DefaultGetFolderUseCase(folderGateway, fileGateway);
     }
 
     @Bean

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/configuration/usecase/FolderUseCaseConfig.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/configuration/usecase/FolderUseCaseConfig.java
@@ -47,7 +47,7 @@ public class FolderUseCaseConfig {
 
     @Bean
     GetRootFolderUseCase getRootFolderUseCase() {
-        return new DefaultGetRootFolderUseCase(aclGateway, memberGateway, folderGateway, fileGateway);
+        return new DefaultGetRootFolderUseCase(eventDispatcher, aclGateway, memberGateway, folderGateway, fileGateway);
     }
 
     @Bean
@@ -57,7 +57,7 @@ public class FolderUseCaseConfig {
 
     @Bean
     GetFolderUseCase getFolderUseCase() {
-        return new DefaultGetFolderUseCase(folderGateway, fileGateway);
+        return new DefaultGetFolderUseCase(aclGateway, folderGateway, fileGateway);
     }
 
     @Bean

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/configuration/usecase/FolderUseCaseConfig.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/configuration/usecase/FolderUseCaseConfig.java
@@ -17,6 +17,7 @@ import com.callv2.drive.application.folder.retrieve.list.DefaultListFoldersUseCa
 import com.callv2.drive.application.folder.retrieve.list.ListFoldersUseCase;
 import com.callv2.drive.application.folder.update.name.DefaultUpdateFolderNameUseCase;
 import com.callv2.drive.application.folder.update.name.UpdateFolderNameUseCase;
+import com.callv2.drive.domain.access.AclGateway;
 import com.callv2.drive.domain.event.EventDispatcher;
 import com.callv2.drive.domain.file.FileGateway;
 import com.callv2.drive.domain.folder.FolderGateway;
@@ -25,16 +26,19 @@ import com.callv2.drive.domain.member.MemberGateway;
 @Configuration
 public class FolderUseCaseConfig {
 
+    private final AclGateway aclGateway;
     private final FolderGateway folderGateway;
     private final FileGateway fileGateway;
     private final MemberGateway memberGateway;
     private final EventDispatcher eventDispatcher;
 
     public FolderUseCaseConfig(
+            final AclGateway aclGateway,
             final FolderGateway folderGateway,
             final FileGateway fileGateway,
             final MemberGateway memberGateway,
             final EventDispatcher eventDispatcher) {
+        this.aclGateway = aclGateway;
         this.folderGateway = folderGateway;
         this.fileGateway = fileGateway;
         this.memberGateway = memberGateway;
@@ -43,7 +47,7 @@ public class FolderUseCaseConfig {
 
     @Bean
     GetRootFolderUseCase getRootFolderUseCase() {
-        return new DefaultGetRootFolderUseCase(memberGateway, folderGateway, fileGateway);
+        return new DefaultGetRootFolderUseCase(aclGateway, memberGateway, folderGateway, fileGateway);
     }
 
     @Bean

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/configuration/usecase/FolderUseCaseConfig.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/configuration/usecase/FolderUseCaseConfig.java
@@ -62,7 +62,7 @@ public class FolderUseCaseConfig {
 
     @Bean
     MoveFolderUseCase moveFolderUseCase() {
-        return new DefaultMoveFolderUseCase(folderGateway);
+        return new DefaultMoveFolderUseCase(aclGateway, folderGateway);
     }
 
     @Bean

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/file/FileJPAGateway.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/file/FileJPAGateway.java
@@ -2,6 +2,7 @@ package com.callv2.drive.infrastructure.file;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Component;
@@ -13,10 +14,13 @@ import com.callv2.drive.domain.folder.FolderID;
 import com.callv2.drive.domain.member.MemberID;
 import com.callv2.drive.domain.pagination.Page;
 import com.callv2.drive.domain.pagination.SearchQuery;
+import com.callv2.drive.infrastructure.access.persistence.FileAclJpaEntity;
 import com.callv2.drive.infrastructure.file.persistence.FileJpaEntity;
 import com.callv2.drive.infrastructure.file.persistence.FileJpaRepository;
 import com.callv2.drive.infrastructure.filter.FilterService;
 import com.callv2.drive.infrastructure.filter.adapter.QueryAdapter;
+
+import jakarta.persistence.criteria.Root;
 
 @Component
 public class FileJPAGateway implements FileGateway {
@@ -56,14 +60,15 @@ public class FileJPAGateway implements FileGateway {
     }
 
     @Override
-    public Page<File> findAll(final SearchQuery searchQuery) {
+    public Page<File> findAllWithMemberAccess(final SearchQuery searchQuery, final MemberID memberId) {
 
         final var page = QueryAdapter.of(searchQuery.pagination());
 
-        final Specification<FileJpaEntity> specification = filterService.buildSpecification(
-                FileJpaEntity.class,
-                searchQuery.filterMethod(),
-                searchQuery.filters());
+        final Specification<FileJpaEntity> specification = fileAclSpecification(memberId.getValue())
+                .and(filterService.buildSpecification(
+                        FileJpaEntity.class,
+                        searchQuery.filterMethod(),
+                        searchQuery.filters()));
 
         final org.springframework.data.domain.Page<FileJpaEntity> pageResult = this.fileRepository
                 .findAll(specification, page);
@@ -94,6 +99,21 @@ public class FileJPAGateway implements FileGateway {
     @Override
     public Long sumAllContentSize() {
         return this.fileRepository.sumAllContentSize();
+    }
+
+    private static Specification<FileJpaEntity> fileAclSpecification(final UUID actorId) {
+        return (root, query, criteriaBuilder) -> {
+
+            if (query == null)
+                return criteriaBuilder.conjunction();
+
+            final Root<FileAclJpaEntity> aclRoot = query.from(FileAclJpaEntity.class);
+
+            return criteriaBuilder.and(
+                    criteriaBuilder.equal(root.get("id"), aclRoot.get("id").get("fileId")),
+                    criteriaBuilder.equal(aclRoot.get("id").get("memberId"), actorId));
+
+        };
     }
 
 }

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/file/FileJPAGateway.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/file/FileJPAGateway.java
@@ -46,8 +46,13 @@ public class FileJPAGateway implements FileGateway {
     }
 
     @Override
-    public Optional<File> findById(FileID id) {
-        return fileRepository.findById(id.getValue()).map(FileJpaEntity::toDomain);
+    public Optional<File> findByIdWithMemberAccess(final FileID id, final MemberID memberId) {
+
+        return fileRepository
+                .findOne(fileByIdSpecification(id.getValue())
+                        .and(fileAclSpecification(memberId.getValue())))
+                .map(FileJpaEntity::toDomain);
+
     }
 
     @Override
@@ -99,6 +104,12 @@ public class FileJPAGateway implements FileGateway {
     @Override
     public Long sumAllContentSize() {
         return this.fileRepository.sumAllContentSize();
+    }
+
+    private static Specification<FileJpaEntity> fileByIdSpecification(final UUID fileId) {
+        return (root, query, criteriaBuilder) -> {
+            return criteriaBuilder.and(criteriaBuilder.equal(root.get("id"), fileId));
+        };
     }
 
     private static Specification<FileJpaEntity> fileAclSpecification(final UUID actorId) {

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/file/FileJPAGateway.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/file/FileJPAGateway.java
@@ -56,9 +56,9 @@ public class FileJPAGateway implements FileGateway {
     }
 
     @Override
-    public List<File> findByFolder(FolderID folderId) {
+    public List<File> findAllActiveByFolder(FolderID folderId) {
         return this.fileRepository
-                .findByFolderId(folderId.getValue())
+                .findByFolderIdAndIsDeletedFalse(folderId.getValue())
                 .stream()
                 .map(FileJpaEntity::toDomain)
                 .toList();

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/file/FileJPAGateway.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/file/FileJPAGateway.java
@@ -37,12 +37,12 @@ public class FileJPAGateway implements FileGateway {
 
     @Override
     public File create(File file) {
-        return fileRepository.save(FileJpaEntity.from(file)).toDomain();
+        return save(file);
     }
 
     @Override
-    public File update(File file) {
-        return fileRepository.save(FileJpaEntity.from(file)).toDomain();
+    public File update(final File file) {
+        return save(file);
     }
 
     @Override
@@ -104,6 +104,11 @@ public class FileJPAGateway implements FileGateway {
     @Override
     public Long sumAllContentSize() {
         return this.fileRepository.sumAllContentSize();
+    }
+
+    private File save(File file) {
+        this.fileRepository.save(FileJpaEntity.from(file));
+        return file;
     }
 
     private static Specification<FileJpaEntity> fileByIdSpecification(final UUID fileId) {

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/file/adapter/FileAdapter.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/file/adapter/FileAdapter.java
@@ -11,7 +11,7 @@ import com.callv2.drive.infrastructure.file.model.DeleteFileContentMessage;
 
 public interface FileAdapter {
 
-    static CreateFileInput adapt(String ownerId, UUID folderId, final MultipartFile aFile) {
+    static CreateFileInput adapt(UUID ownerId, UUID folderId, final MultipartFile aFile) {
         try {
             return CreateFileInput.of(
                     ownerId,

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/file/adapter/FileAdapter.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/file/adapter/FileAdapter.java
@@ -26,7 +26,7 @@ public interface FileAdapter {
     }
 
     static DeleteFileContentInput adapt(DeleteFileContentMessage message) {
-        return DeleteFileContentInput.of(message.data().fileId());
+        return DeleteFileContentInput.of(message.data().fileId(), message.data().deleterId());
     }
 
 }

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/file/model/DeleteFileContentMessage.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/file/model/DeleteFileContentMessage.java
@@ -8,6 +8,7 @@ public record DeleteFileContentMessage(Data data) implements Serializable {
 
     public record Data(
             UUID fileId,
+            UUID deleterId,
             String ownerId,
             UUID folderId,
             String name,

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/file/model/FileListResponse.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/file/model/FileListResponse.java
@@ -5,7 +5,7 @@ import java.util.UUID;
 
 public record FileListResponse(
         UUID id,
-        String ownerId,
+        UUID ownerId,
         UUID folderId,
         String name,
         String contentType,

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/file/model/GetFileResponse.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/file/model/GetFileResponse.java
@@ -5,7 +5,7 @@ import java.util.UUID;
 
 public record GetFileResponse(
         UUID id,
-        String ownerId,
+        UUID ownerId,
         UUID folderId,
         String name,
         String contentType,

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/file/model/GetFileResponse.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/file/model/GetFileResponse.java
@@ -10,7 +10,11 @@ public record GetFileResponse(
         String name,
         String contentType,
         Long contentSize,
+        UUID createdBy,
         Instant createdAt,
-        Instant updatedAt) {
+        UUID updatedBy,
+        Instant updatedAt,
+        UUID deletedBy,
+        Instant deletedAt) {
 
 }

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/file/persistence/FileJpaEntity.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/file/persistence/FileJpaEntity.java
@@ -22,8 +22,11 @@ public class FileJpaEntity {
     @Id
     private UUID id;
 
+    @Column(name = "creator_id", nullable = false)
+    private UUID creatorId;
+
     @Column(name = "owner_id", nullable = false)
-    private String ownerId;
+    private UUID ownerId;
 
     @Column(name = "folder_id", nullable = false)
     private UUID folderId;
@@ -54,7 +57,8 @@ public class FileJpaEntity {
 
     private FileJpaEntity(
             final UUID id,
-            final String ownerId,
+            final UUID creatorId,
+            final UUID ownerId,
             final UUID folderId,
             final String name,
             final String contentType,
@@ -65,6 +69,7 @@ public class FileJpaEntity {
             final Instant deletedAt,
             final Boolean isDeleted) {
         this.id = id;
+        this.creatorId = creatorId;
         this.ownerId = ownerId;
         this.folderId = folderId;
         this.name = name;
@@ -83,6 +88,7 @@ public class FileJpaEntity {
     public static FileJpaEntity from(final File file) {
         return new FileJpaEntity(
                 file.getId().getValue(),
+                file.getCreator().getValue(),
                 file.getOwner().getValue(),
                 file.getFolder().getValue(),
                 file.getName().value(),
@@ -98,6 +104,7 @@ public class FileJpaEntity {
     public File toDomain() {
         return File.with(
                 FileID.of(getId()),
+                MemberID.of(getCreatorId()),
                 MemberID.of(getOwnerId()),
                 FolderID.of(getFolderId()),
                 FileName.of(getName()),
@@ -116,11 +123,19 @@ public class FileJpaEntity {
         this.id = id;
     }
 
-    public String getOwnerId() {
+    public UUID getCreatorId() {
+        return creatorId;
+    }
+
+    public void setCreatorId(UUID creatorId) {
+        this.creatorId = creatorId;
+    }
+
+    public UUID getOwnerId() {
         return ownerId;
     }
 
-    public void setOwnerId(String ownerId) {
+    public void setOwnerId(UUID ownerId) {
         this.ownerId = ownerId;
     }
 
@@ -192,8 +207,8 @@ public class FileJpaEntity {
         return isDeleted;
     }
 
-    public void setIsDeleted(Boolean isDelete) {
-        this.isDeleted = isDelete;
+    public void setIsDeleted(Boolean isDeleted) {
+        this.isDeleted = isDeleted;
     }
 
 }

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/file/persistence/FileJpaEntity.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/file/persistence/FileJpaEntity.java
@@ -43,6 +43,12 @@ public class FileJpaEntity {
     @Column(name = "content_size", nullable = false)
     private Long contentSize;
 
+    @Column(name = "deleted_by")
+    private UUID deletedBy;
+
+    @Column(name = "updated_by", nullable = false)
+    private UUID updatedBy;
+
     @Column(name = "created_at", nullable = false)
     private Instant createdAt;
 
@@ -64,6 +70,8 @@ public class FileJpaEntity {
             final String contentType,
             final String contentLocation,
             final Long contentSize,
+            final UUID updatedBy,
+            final UUID deletedBy,
             final Instant createdAt,
             final Instant updatedAt,
             final Instant deletedAt,
@@ -76,6 +84,8 @@ public class FileJpaEntity {
         this.contentType = contentType;
         this.contentStorageKey = contentLocation;
         this.contentSize = contentSize;
+        this.updatedBy = updatedBy;
+        this.deletedBy = deletedBy;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
         this.deletedAt = deletedAt;
@@ -95,6 +105,8 @@ public class FileJpaEntity {
                 file.getContent().type(),
                 file.getContent().storageKey(),
                 file.getContent().size(),
+                file.getUpdatedBy().getValue(),
+                file.getDeletedBy() != null ? file.getDeletedBy().getValue() : null,
                 file.getCreatedAt(),
                 file.getUpdatedAt(),
                 file.getDeletedAt(),
@@ -109,6 +121,8 @@ public class FileJpaEntity {
                 FolderID.of(getFolderId()),
                 FileName.of(getName()),
                 Content.of(getContentStorageKey(), getContentType(), getContentSize()),
+                MemberID.of(getUpdatedBy()),
+                getDeletedBy() != null ? MemberID.of(getDeletedBy()) : null,
                 getCreatedAt(),
                 getUpdatedAt(),
                 getDeletedAt(),
@@ -177,6 +191,22 @@ public class FileJpaEntity {
 
     public void setContentSize(Long contentSize) {
         this.contentSize = contentSize;
+    }
+
+    public UUID getDeletedBy() {
+        return deletedBy;
+    }
+
+    public void setDeletedBy(UUID deletedBy) {
+        this.deletedBy = deletedBy;
+    }
+
+    public UUID getUpdatedBy() {
+        return updatedBy;
+    }
+
+    public void setUpdatedBy(UUID updatedBy) {
+        this.updatedBy = updatedBy;
     }
 
     public Instant getCreatedAt() {

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/file/persistence/FileJpaRepository.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/file/persistence/FileJpaRepository.java
@@ -15,7 +15,7 @@ public interface FileJpaRepository extends JpaRepository<FileJpaEntity, UUID> {
 
     List<FileJpaEntity> findByFolderId(UUID folderId);
 
-    List<FileJpaEntity> findByOwnerId(String ownerId);
+    List<FileJpaEntity> findByOwnerId(UUID ownerId);
 
     @Query("select coalesce(sum(f.contentSize), 0) from File f")
     Long sumAllContentSize();

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/file/persistence/FileJpaRepository.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/file/persistence/FileJpaRepository.java
@@ -3,15 +3,12 @@ package com.callv2.drive.infrastructure.file.persistence;
 import java.util.List;
 import java.util.UUID;
 
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 
-public interface FileJpaRepository extends JpaRepository<FileJpaEntity, UUID> {
-
-    Page<FileJpaEntity> findAll(Specification<FileJpaEntity> whereClause, Pageable page);
+public interface FileJpaRepository extends
+        JpaRepository<FileJpaEntity, UUID>, JpaSpecificationExecutor<FileJpaEntity> {
 
     List<FileJpaEntity> findByFolderId(UUID folderId);
 

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/file/persistence/FileJpaRepository.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/file/persistence/FileJpaRepository.java
@@ -10,7 +10,7 @@ import org.springframework.data.jpa.repository.Query;
 public interface FileJpaRepository extends
         JpaRepository<FileJpaEntity, UUID>, JpaSpecificationExecutor<FileJpaEntity> {
 
-    List<FileJpaEntity> findByFolderId(UUID folderId);
+    List<FileJpaEntity> findByFolderIdAndIsDeletedFalse(UUID folderId);
 
     List<FileJpaEntity> findByOwnerId(UUID ownerId);
 

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/file/presenter/FilePresenter.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/file/presenter/FilePresenter.java
@@ -21,8 +21,12 @@ public interface FilePresenter {
                 output.name(),
                 output.contentType(),
                 output.contentSize(),
+                output.creatorId(),
                 output.createdAt(),
-                output.updatedAt());
+                output.updaterId(),
+                output.updatedAt(),
+                output.deleterId(),
+                output.deletedAt());
     }
 
     static FileListResponse present(final FileListOutput output) {

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/folder/FolderJpaGateway.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/folder/FolderJpaGateway.java
@@ -38,7 +38,7 @@ public class FolderJpaGateway implements FolderGateway {
     }
 
     @Override
-    public Optional<Folder> findRoot(final MemberID owner) {
+    public Optional<Folder> findMemberRootFolder(final MemberID owner) {
         return this.folderRepository.findByRootFolderTrueAndOwnerId(owner.getValue()).map(FolderJpaEntity::toDomain);
     }
 

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/folder/FolderJpaGateway.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/folder/FolderJpaGateway.java
@@ -12,6 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.callv2.drive.domain.folder.Folder;
 import com.callv2.drive.domain.folder.FolderGateway;
 import com.callv2.drive.domain.folder.FolderID;
+import com.callv2.drive.domain.member.MemberID;
 import com.callv2.drive.domain.pagination.Page;
 import com.callv2.drive.domain.pagination.SearchQuery;
 import com.callv2.drive.infrastructure.filter.FilterService;
@@ -33,8 +34,8 @@ public class FolderJpaGateway implements FolderGateway {
     }
 
     @Override
-    public Optional<Folder> findRoot() {
-        return this.folderRepository.findByRootFolderTrue().map(FolderJpaEntity::toDomain);
+    public Optional<Folder> findRoot(final MemberID owner) {
+        return this.folderRepository.findByRootFolderTrueAndOwnerId(owner.getValue()).map(FolderJpaEntity::toDomain);
     }
 
     @Override

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/folder/FolderJpaGateway.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/folder/FolderJpaGateway.java
@@ -71,7 +71,7 @@ public class FolderJpaGateway implements FolderGateway {
     public Optional<Folder> findByIdWithMemberAccess(final FolderID id, final MemberID actorId) {
 
         return this.folderRepository
-                .findOne(folderAclSpecification(actorId.getValue()))
+                .findOne(folderAclByIdSpecification(id.getValue(), actorId.getValue()))
                 .map(FolderJpaEntity::toDomain);
 
     }
@@ -120,6 +120,22 @@ public class FolderJpaGateway implements FolderGateway {
                     criteriaBuilder.equal(aclRoot.get("id").get("memberId"), actorId));
 
         };
+    }
+
+    private static Specification<FolderJpaEntity> folderAclByIdSpecification(final UUID folderId, final UUID actorId) {
+
+        return (root, query, criteriaBuilder) -> {
+            if (query == null)
+                return criteriaBuilder.conjunction();
+
+            Root<FolderAclJpaEntity> aclRoot = query.from(FolderAclJpaEntity.class);
+
+            return criteriaBuilder.and(
+                    criteriaBuilder.equal(root.get("id"), folderId),
+                    criteriaBuilder.equal(root.get("id"), aclRoot.get("id").get("folderId")),
+                    criteriaBuilder.equal(aclRoot.get("id").get("memberId"), actorId));
+        };
+
     }
 
 }

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/folder/FolderJpaGateway.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/folder/FolderJpaGateway.java
@@ -3,6 +3,7 @@ package com.callv2.drive.infrastructure.folder;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import org.springframework.data.jpa.domain.Specification;
@@ -15,10 +16,13 @@ import com.callv2.drive.domain.folder.FolderID;
 import com.callv2.drive.domain.member.MemberID;
 import com.callv2.drive.domain.pagination.Page;
 import com.callv2.drive.domain.pagination.SearchQuery;
+import com.callv2.drive.infrastructure.access.persistence.FolderAclJpaEntity;
 import com.callv2.drive.infrastructure.filter.FilterService;
 import com.callv2.drive.infrastructure.filter.adapter.QueryAdapter;
 import com.callv2.drive.infrastructure.folder.persistence.FolderJpaEntity;
 import com.callv2.drive.infrastructure.folder.persistence.FolderJpaRepository;
+
+import jakarta.persistence.criteria.Root;
 
 @Component
 public class FolderJpaGateway implements FolderGateway {
@@ -64,8 +68,12 @@ public class FolderJpaGateway implements FolderGateway {
     }
 
     @Override
-    public Optional<Folder> findById(FolderID id) {
-        return this.folderRepository.findById(id.getValue()).map(FolderJpaEntity::toDomain);
+    public Optional<Folder> findByIdWithMemberAccess(final FolderID id, final MemberID actorId) {
+
+        return this.folderRepository
+                .findOne(folderAclSpecification(actorId.getValue()))
+                .map(FolderJpaEntity::toDomain);
+
     }
 
     private Folder save(Folder folder) {
@@ -73,13 +81,14 @@ public class FolderJpaGateway implements FolderGateway {
     }
 
     @Override
-    public Page<Folder> findAll(SearchQuery searchQuery) {
+    public Page<Folder> findAllWithMemberAccess(final SearchQuery searchQuery, final MemberID actorId) {
         final var page = QueryAdapter.of(searchQuery.pagination());
 
-        final Specification<FolderJpaEntity> specification = filterService.buildSpecification(
-                FolderJpaEntity.class,
-                searchQuery.filterMethod(),
-                searchQuery.filters());
+        final Specification<FolderJpaEntity> specification = folderAclSpecification(actorId.getValue())
+                .and(filterService.buildSpecification(
+                        FolderJpaEntity.class,
+                        searchQuery.filterMethod(),
+                        searchQuery.filters()));
 
         final org.springframework.data.domain.Page<FolderJpaEntity> pageResult = this.folderRepository.findAll(
                 specification,
@@ -96,6 +105,21 @@ public class FolderJpaGateway implements FolderGateway {
     @Override
     public void deleteById(FolderID id) {
         this.folderRepository.deleteById(id.getValue());
+    }
+
+    private static Specification<FolderJpaEntity> folderAclSpecification(final UUID actorId) {
+        return (root, query, criteriaBuilder) -> {
+
+            if (query == null)
+                return criteriaBuilder.conjunction();
+
+            Root<FolderAclJpaEntity> aclRoot = query.from(FolderAclJpaEntity.class);
+
+            return criteriaBuilder.and(
+                    criteriaBuilder.equal(root.get("id"), aclRoot.get("id").get("folderId")),
+                    criteriaBuilder.equal(aclRoot.get("id").get("memberId"), actorId));
+
+        };
     }
 
 }

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/folder/FolderJpaGateway.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/folder/FolderJpaGateway.java
@@ -43,9 +43,11 @@ public class FolderJpaGateway implements FolderGateway {
     }
 
     @Override
-    public Set<Folder> findByParentFolderId(FolderID parentFolderId) {
+    public Set<Folder> findByParentFolderIdWithMemberAccess(FolderID parentFolderId, final MemberID actorId) {
         return this.folderRepository
-                .findAllByParentFolderId(parentFolderId.getValue())
+                .findAll(
+                        findByParentFolderIdSpecification(parentFolderId.getValue())
+                                .and(folderAclSpecification(actorId.getValue())))
                 .stream()
                 .map(FolderJpaEntity::toDomain)
                 .collect(Collectors.toSet());
@@ -70,8 +72,11 @@ public class FolderJpaGateway implements FolderGateway {
     @Override
     public Optional<Folder> findByIdWithMemberAccess(final FolderID id, final MemberID actorId) {
 
+        final var specification = folderByIdSpecification(id.getValue())
+                .and(folderAclSpecification(actorId.getValue()));
+
         return this.folderRepository
-                .findOne(folderAclByIdSpecification(id.getValue(), actorId.getValue()))
+                .findOne(specification)
                 .map(FolderJpaEntity::toDomain);
 
     }
@@ -113,7 +118,7 @@ public class FolderJpaGateway implements FolderGateway {
             if (query == null)
                 return criteriaBuilder.conjunction();
 
-            Root<FolderAclJpaEntity> aclRoot = query.from(FolderAclJpaEntity.class);
+            final Root<FolderAclJpaEntity> aclRoot = query.from(FolderAclJpaEntity.class);
 
             return criteriaBuilder.and(
                     criteriaBuilder.equal(root.get("id"), aclRoot.get("id").get("folderId")),
@@ -122,20 +127,16 @@ public class FolderJpaGateway implements FolderGateway {
         };
     }
 
-    private static Specification<FolderJpaEntity> folderAclByIdSpecification(final UUID folderId, final UUID actorId) {
-
+    private static Specification<FolderJpaEntity> folderByIdSpecification(final UUID folderId) {
         return (root, query, criteriaBuilder) -> {
-            if (query == null)
-                return criteriaBuilder.conjunction();
-
-            Root<FolderAclJpaEntity> aclRoot = query.from(FolderAclJpaEntity.class);
-
-            return criteriaBuilder.and(
-                    criteriaBuilder.equal(root.get("id"), folderId),
-                    criteriaBuilder.equal(root.get("id"), aclRoot.get("id").get("folderId")),
-                    criteriaBuilder.equal(aclRoot.get("id").get("memberId"), actorId));
+            return criteriaBuilder.and(criteriaBuilder.equal(root.get("id"), folderId));
         };
+    }
 
+    private static Specification<FolderJpaEntity> findByParentFolderIdSpecification(final UUID parentFolderId) {
+        return (root, query, criteriaBuilder) -> {
+            return criteriaBuilder.and(criteriaBuilder.equal(root.get("parentFolderId"), parentFolderId));
+        };
     }
 
 }

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/folder/adapter/FolderAdapter.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/folder/adapter/FolderAdapter.java
@@ -12,8 +12,8 @@ public interface FolderAdapter {
         return CreateFolderInput.from(ownerId, request.name(), request.parentFolderId());
     }
 
-    static GetFolderInput adapt(UUID id) {
-        return GetFolderInput.with(id);
+    static GetFolderInput adapt(UUID folderId, UUID actorId) {
+        return GetFolderInput.with(folderId, actorId);
     }
 
 }

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/folder/adapter/FolderAdapter.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/folder/adapter/FolderAdapter.java
@@ -8,8 +8,8 @@ import com.callv2.drive.infrastructure.folder.model.CreateFolderRequest;
 
 public interface FolderAdapter {
 
-    static CreateFolderInput adapt(CreateFolderRequest request, UUID ownerId) {
-        return CreateFolderInput.from(ownerId, request.name(), request.parentFolderId());
+    static CreateFolderInput adapt(CreateFolderRequest request, UUID creatorId) {
+        return CreateFolderInput.from(creatorId, request.name(), request.parentFolderId());
     }
 
     static GetFolderInput adapt(UUID folderId, UUID actorId) {

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/folder/adapter/FolderAdapter.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/folder/adapter/FolderAdapter.java
@@ -8,7 +8,7 @@ import com.callv2.drive.infrastructure.folder.model.CreateFolderRequest;
 
 public interface FolderAdapter {
 
-    static CreateFolderInput adapt(CreateFolderRequest request, String ownerId) {
+    static CreateFolderInput adapt(CreateFolderRequest request, UUID ownerId) {
         return CreateFolderInput.from(ownerId, request.name(), request.parentFolderId());
     }
 

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/folder/model/GetFolderResponse.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/folder/model/GetFolderResponse.java
@@ -11,7 +11,7 @@ public record GetFolderResponse(
         UUID parentFolder,
         Set<GetFolderResponse.SubFolder> subFolders,
         Set<GetFolderResponse.File> files,
-        String ownerId,
+        UUID ownerId,
         Instant createdAt,
         Instant updatedAt) {
 

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/folder/persistence/FolderJpaEntity.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/folder/persistence/FolderJpaEntity.java
@@ -26,6 +26,9 @@ public class FolderJpaEntity {
     @Column(name = "name", nullable = false)
     private String name;
 
+    @Column(name = "creator_id", nullable = false)
+    private UUID creatorId;
+
     @Column(name = "owner_id", nullable = false)
     private UUID ownerId;
 
@@ -45,6 +48,7 @@ public class FolderJpaEntity {
             final UUID id,
             final Boolean rootFolder,
             final String name,
+            final UUID creatorId,
             final UUID ownerId,
             final UUID parentFolderId,
             final Instant createdAt,
@@ -53,6 +57,7 @@ public class FolderJpaEntity {
         this.id = id;
         this.rootFolder = rootFolder;
         this.name = name;
+        this.creatorId = creatorId;
         this.ownerId = ownerId;
         this.parentFolderId = parentFolderId;
         this.createdAt = createdAt;
@@ -71,6 +76,7 @@ public class FolderJpaEntity {
                 folder.getId().getValue(),
                 folder.isRootFolder(),
                 folder.getName().value(),
+                folder.getCreator().getValue(),
                 folder.getOwner().getValue(),
                 parentFolderId,
                 folder.getCreatedAt(),
@@ -83,6 +89,7 @@ public class FolderJpaEntity {
     public Folder toDomain() {
         return Folder.with(
                 FolderID.of(id),
+                MemberID.of(creatorId),
                 MemberID.of(ownerId),
                 FolderName.of(name),
                 FolderID.of(parentFolderId),
@@ -124,6 +131,14 @@ public class FolderJpaEntity {
         this.ownerId = ownerId;
     }
 
+    public UUID getCreatorId() {
+        return creatorId;
+    }
+
+    public void setCreatorId(UUID creatorId) {
+        this.creatorId = creatorId;
+    }
+
     public UUID getParentFolderId() {
         return parentFolderId;
     }
@@ -155,4 +170,5 @@ public class FolderJpaEntity {
     public void setDeletedAt(Instant deletedAt) {
         this.deletedAt = deletedAt;
     }
+
 }

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/folder/persistence/FolderJpaEntity.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/folder/persistence/FolderJpaEntity.java
@@ -27,7 +27,7 @@ public class FolderJpaEntity {
     private String name;
 
     @Column(name = "owner_id", nullable = false)
-    private String ownerId;
+    private UUID ownerId;
 
     @Column(name = "parent_folder_id")
     private UUID parentFolderId;
@@ -45,7 +45,7 @@ public class FolderJpaEntity {
             final UUID id,
             final Boolean rootFolder,
             final String name,
-            final String ownerId,
+            final UUID ownerId,
             final UUID parentFolderId,
             final Instant createdAt,
             final Instant updatedAt,
@@ -116,11 +116,11 @@ public class FolderJpaEntity {
         this.name = name;
     }
 
-    public String getOwnerId() {
+    public UUID getOwnerId() {
         return ownerId;
     }
 
-    public void setOwnerId(String ownerId) {
+    public void setOwnerId(UUID ownerId) {
         this.ownerId = ownerId;
     }
 

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/folder/persistence/FolderJpaRepository.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/folder/persistence/FolderJpaRepository.java
@@ -11,7 +11,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FolderJpaRepository extends JpaRepository<FolderJpaEntity, UUID> {
 
-    Optional<FolderJpaEntity> findByRootFolderTrue();
+    Optional<FolderJpaEntity> findByRootFolderTrueAndOwnerId(UUID ownerId);
 
     List<FolderJpaEntity> findAllByParentFolderId(UUID parentFolderId);
 

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/folder/persistence/FolderJpaRepository.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/folder/persistence/FolderJpaRepository.java
@@ -8,13 +8,19 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
 
-public interface FolderJpaRepository extends JpaRepository<FolderJpaEntity, UUID> {
+public interface FolderJpaRepository extends
+        JpaRepository<FolderJpaEntity, UUID>,
+        JpaSpecificationExecutor<FolderJpaEntity> {
 
     Optional<FolderJpaEntity> findByRootFolderTrueAndOwnerId(UUID ownerId);
 
     List<FolderJpaEntity> findAllByParentFolderId(UUID parentFolderId);
 
-    Page<FolderJpaEntity> findAll(Specification<FolderJpaEntity> whereClause, Pageable page);
+    // @NonNull
+    // Page<FolderJpaEntity> findAll(@Nullable Specification<FolderJpaEntity> whereClause, @NonNull Pageable page);
 
 }

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/folder/persistence/FolderJpaRepository.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/folder/persistence/FolderJpaRepository.java
@@ -1,6 +1,5 @@
 package com.callv2.drive.infrastructure.folder.persistence;
 
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -12,7 +11,5 @@ public interface FolderJpaRepository extends
         JpaSpecificationExecutor<FolderJpaEntity> {
 
     Optional<FolderJpaEntity> findByRootFolderTrueAndOwnerId(UUID ownerId);
-
-    List<FolderJpaEntity> findAllByParentFolderId(UUID parentFolderId);
 
 }

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/folder/persistence/FolderJpaRepository.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/folder/persistence/FolderJpaRepository.java
@@ -4,13 +4,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
-import org.springframework.lang.NonNull;
-import org.springframework.lang.Nullable;
 
 public interface FolderJpaRepository extends
         JpaRepository<FolderJpaEntity, UUID>,
@@ -19,8 +14,5 @@ public interface FolderJpaRepository extends
     Optional<FolderJpaEntity> findByRootFolderTrueAndOwnerId(UUID ownerId);
 
     List<FolderJpaEntity> findAllByParentFolderId(UUID parentFolderId);
-
-    // @NonNull
-    // Page<FolderJpaEntity> findAll(@Nullable Specification<FolderJpaEntity> whereClause, @NonNull Pageable page);
 
 }

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/member/DefaultMemberGateway.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/member/DefaultMemberGateway.java
@@ -37,7 +37,7 @@ public class DefaultMemberGateway implements MemberGateway {
     @Override
     public Member create(final Member member) {
         if (this.memberJpaRepository.existsById(member.getId().getValue()))
-            throw AlreadyExistsException.with(Member.class, member.getId().getValue());
+            throw AlreadyExistsException.with(Member.class, member.getId().getStringValue());
 
         return this.memberJpaRepository.save(MemberJpaEntity.fromDomain(member)).toDomain();
     }
@@ -81,7 +81,7 @@ public class DefaultMemberGateway implements MemberGateway {
     public Member update(final Member member) {
 
         if (!this.memberJpaRepository.existsById(member.getId().getValue()))
-            throw NotFoundException.with(Member.class, member.getId().getValue());
+            throw NotFoundException.with(Member.class, member.getId().getStringValue());
 
         final MemberJpaEntity memberJpa = MemberJpaEntity.fromDomain(member);
         final Integer rowsUpdated = memberJpaRepository.update(

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/member/model/MemberCreatedMessage.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/member/model/MemberCreatedMessage.java
@@ -3,11 +3,12 @@ package com.callv2.drive.infrastructure.member.model;
 import java.io.Serializable;
 import java.time.Instant;
 import java.util.Set;
+import java.util.UUID;
 
 public record MemberCreatedMessage(Data data) implements Serializable {
 
     public record Data(
-            String id,
+            UUID id,
             String username,
             String email,
             String nickname,

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/member/model/MemberQuotaListResponse.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/member/model/MemberQuotaListResponse.java
@@ -1,5 +1,7 @@
 package com.callv2.drive.infrastructure.member.model;
 
-public record MemberQuotaListResponse(String memberId, String username, Long total) {
+import java.util.UUID;
+
+public record MemberQuotaListResponse(UUID memberId, String username, Long total) {
 
 }

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/member/model/MemberQuotaResponse.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/member/model/MemberQuotaResponse.java
@@ -1,5 +1,7 @@
 package com.callv2.drive.infrastructure.member.model;
 
-public record MemberQuotaResponse(String memberId, String username, Long used, Long total, Long available) {
+import java.util.UUID;
+
+public record MemberQuotaResponse(UUID memberId, String username, Long used, Long total, Long available) {
 
 }

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/member/model/MemberUpdatedMessage.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/member/model/MemberUpdatedMessage.java
@@ -3,11 +3,12 @@ package com.callv2.drive.infrastructure.member.model;
 import java.io.Serializable;
 import java.time.Instant;
 import java.util.Set;
+import java.util.UUID;
 
 public record MemberUpdatedMessage(Data data) implements Serializable {
 
     public record Data(
-            String id,
+            UUID id,
             String username,
             String email,
             String nickname,

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/member/model/QuotaRequestListResponse.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/member/model/QuotaRequestListResponse.java
@@ -1,6 +1,7 @@
 package com.callv2.drive.infrastructure.member.model;
 
 import java.time.Instant;
+import java.util.UUID;
 
 import com.callv2.drive.domain.member.QuotaUnit;
 
@@ -10,7 +11,7 @@ public record QuotaRequestListResponse(
         QuotaUnit unit,
         Instant requestedAt) {
 
-    public record Member(String id, String username) {
+    public record Member(UUID id, String username) {
     }
 
 }

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/member/persistence/MemberJpaEntity.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/member/persistence/MemberJpaEntity.java
@@ -1,6 +1,7 @@
 package com.callv2.drive.infrastructure.member.persistence;
 
 import java.time.Instant;
+import java.util.UUID;
 
 import com.callv2.drive.domain.member.Member;
 import com.callv2.drive.domain.member.MemberID;
@@ -22,7 +23,7 @@ import jakarta.persistence.Table;
 public class MemberJpaEntity {
 
     @Id
-    private String id;
+    private UUID id;
 
     private String username;
 
@@ -57,7 +58,7 @@ public class MemberJpaEntity {
     private Long synchronizedVersion;
 
     public MemberJpaEntity(
-            final String id,
+            final UUID id,
             final String username,
             final String nickname,
             final Long quotaInBytes,
@@ -128,11 +129,11 @@ public class MemberJpaEntity {
                 member.getSynchronizedVersion());
     }
 
-    public String getId() {
+    public UUID getId() {
         return id;
     }
 
-    public void setId(String id) {
+    public void setId(UUID id) {
         this.id = id;
     }
 

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/member/persistence/MemberJpaRepository.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/member/persistence/MemberJpaRepository.java
@@ -1,6 +1,7 @@
 package com.callv2.drive.infrastructure.member.persistence;
 
 import java.time.Instant;
+import java.util.UUID;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -13,7 +14,7 @@ import org.springframework.data.repository.query.Param;
 import com.callv2.drive.domain.member.QuotaRequestPreview;
 import com.callv2.drive.domain.member.QuotaUnit;
 
-public interface MemberJpaRepository extends JpaRepository<MemberJpaEntity, String> {
+public interface MemberJpaRepository extends JpaRepository<MemberJpaEntity, UUID> {
 
     Page<MemberJpaEntity> findAll(Specification<MemberJpaEntity> whereClause, Pageable page);
 
@@ -53,7 +54,7 @@ public interface MemberJpaRepository extends JpaRepository<MemberJpaEntity, Stri
             and (m.synchronizedVersion is null or :synchronizedVersion >= m.synchronizedVersion)
             """)
     Integer update(
-            @Param("id") String id,
+            @Param("id") UUID id,
             @Param("username") String username,
             @Param("nickname") String nickname,
             @Param("quotaInBytes") Long quotaInBytes,

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/messaging/listener/access/AclUpdatedListener.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/messaging/listener/access/AclUpdatedListener.java
@@ -1,0 +1,13 @@
+package com.callv2.drive.infrastructure.messaging.listener.access;
+
+import com.callv2.drive.infrastructure.access.model.UpdateAclMessage;
+import com.callv2.drive.infrastructure.messaging.listener.Listener;
+
+public class AclUpdatedListener implements Listener<UpdateAclMessage> {
+
+    @Override
+    public void handle(final UpdateAclMessage message) {
+
+    }
+
+}

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/security/SecurityContext.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/security/SecurityContext.java
@@ -1,6 +1,7 @@
 package com.callv2.drive.infrastructure.security;
 
 import java.util.Optional;
+import java.util.UUID;
 
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -10,10 +11,11 @@ public final class SecurityContext {
     private SecurityContext() {
     }
 
-    public static String getAuthenticatedUser() {
+    public static UUID getAuthenticatedUserId() {
         return Optional
                 .ofNullable(SecurityContextHolder.getContext().getAuthentication())
                 .map(Authentication::getName)
+                .map(UUID::fromString)
                 .orElseThrow();
     }
 

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/storage/FileSystemStorage.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/storage/FileSystemStorage.java
@@ -8,17 +8,30 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.Objects;
+import java.util.UUID;
 
 import com.callv2.drive.domain.exception.InternalErrorException;
 import com.callv2.drive.domain.exception.StorageKeyAlreadyExistsException;
-import com.callv2.drive.domain.storage.StorageService;
+import com.callv2.drive.domain.storage.StorageGateway;
+import com.callv2.drive.domain.storage.StorageKeyGenerator;
 
-public class FileSystemStorageService implements StorageService {
+public class FileSystemStorage implements StorageGateway, StorageKeyGenerator {
 
     private final Path rootLocation;
 
-    public FileSystemStorageService(final Path rootLocation) {
+    public FileSystemStorage(final Path rootLocation) {
         this.rootLocation = Objects.requireNonNull(rootLocation).toAbsolutePath().normalize();
+    }
+
+    @Override
+    public String generate() {
+        while (true) {
+            final String key = UUID.randomUUID().toString();
+            final Path destinationFile = this.rootLocation.resolve(Paths.get(key)).normalize().toAbsolutePath();
+            if (!Files.exists(destinationFile)) {
+                return key;
+            }
+        }
     }
 
     @Override


### PR DESCRIPTION
This pull request introduces significant improvements to file access control and auditing in the application layer. The main changes are the addition of member-aware access checks for all file operations, updates to input and output models to include actor and audit fields, and a refactor to use `StorageGateway` instead of `StorageService`. These changes enhance security by ensuring only authorized users can perform actions, and improve traceability of file operations.

**Access Control and Security Enhancements:**

* All file operations (`create`, `get`, `delete`, `list`) now check member access by using methods like `findByIdWithMemberAccess` and passing `MemberID` to ensure only authorized users can access or modify files and folders. (`[[1]](diffhunk://#diff-ace2577502d53e941bd813c0603260d092ab5d1a9bd54dfb0e8b8bc926a5a843L24-R25)`, `[[2]](diffhunk://#diff-cd729991997807230b871367af44b75081b32d4c3dfa95628f827f404cd6ccfcR28-R31)`, `[[3]](diffhunk://#diff-65c307fcc327d5079665581992be9b29e96f4c3a7d440badce9227d36aeb9d63L32-R46)`, `[[4]](diffhunk://#diff-184f662f623a205fbe47477a43c981f96c7f790a849f8f977e2c1a1e8e1a92a8L21-R24)`, `[[5]](diffhunk://#diff-2eb690d901d069b86ae77abb6fd19c4aa37566ed1835f00b62d0a8aaa905d754L18-R20)`)
* Input models for file operations now require both the file/folder ID and the actor's (user's) ID, enforcing explicit access checks. (`[[1]](diffhunk://#diff-145391cd95729b529f15f04534b3f83ca36a2fe689376c44ff1ba04551116b18L5-R8)`, `[[2]](diffhunk://#diff-0f2f4cf2b87167a04d1cfd53da688698bd57cec18b970c7fef2e2ab7ca6c76e4L5-R8)`, `[[3]](diffhunk://#diff-79f5b0090985d6c4f83c53f7f37c456843a724aaf8de7df84274de620e4e13a2L5-R7)`, `[[4]](diffhunk://#diff-748c8f26e33aa38460b1f26643b0ac532991101d50eb4297a7881bb0ee9db134L5-R8)`, `[[5]](diffhunk://#diff-7ee06a1aab9bc7d55955081385d9202315c1e52b9a959afdcfcc46bb961ec42eR1-R11)`)

**File Creation and ACL Integration:**

* File creation now validates write permissions using ACLs and creates inherited ACLs for new files. The process checks the creator's access, validates quotas, and notifies relevant events. (`[application/src/main/java/com/callv2/drive/application/file/create/DefaultCreateFileUseCase.javaL23-R132](diffhunk://#diff-a4fafd915d541ac669c652b8f4eba69bbf734f8b65c18ad9d6b42ba1ae40b328L23-R132)`)
* The `CreateFileInput` model is updated to use `UUID` for `creatorId` (instead of `String`), aligning with other input models and improving consistency. (`[application/src/main/java/com/callv2/drive/application/file/create/CreateFileInput.javaL6-R21](diffhunk://#diff-8b7ead8b4d406afd16f6388f781261c41c91c6dc66cedd072e718102445b6580L6-R21)`)

**Audit and Output Model Improvements:**

* Output models for file retrieval now include audit fields: `creatorId`, `updaterId`, `deleterId`, and their respective timestamps, providing better traceability for file operations. (`[application/src/main/java/com/callv2/drive/application/file/retrieve/get/GetFileOutput.javaL10-R35](diffhunk://#diff-52d10d36c09fbcd428a1ca66646946907b07e52d2aae280a8ebc16a1dbd6e0efL10-R35)`)

**Storage Layer Refactor:**

* The application layer is refactored to use `StorageGateway` instead of `StorageService` for file content operations, improving abstraction and consistency in storage handling. (`[[1]](diffhunk://#diff-ace2577502d53e941bd813c0603260d092ab5d1a9bd54dfb0e8b8bc926a5a843L6-R16)`, `[[2]](diffhunk://#diff-cd729991997807230b871367af44b75081b32d4c3dfa95628f827f404cd6ccfcL9-R19)`, `[[3]](diffhunk://#diff-a4fafd915d541ac669c652b8f4eba69bbf734f8b65c18ad9d6b42ba1ae40b328L23-R132)`, `[[4]](diffhunk://#diff-a4fafd915d541ac669c652b8f4eba69bbf734f8b65c18ad9d6b42ba1ae40b328L105-R152)`, `[[5]](diffhunk://#diff-a4fafd915d541ac669c652b8f4eba69bbf734f8b65c18ad9d6b42ba1ae40b328L129-R162)`)

**New Input Model for File Listing:**

* Introduced the `FileListInput` record to support member-aware file listing queries, further enforcing access control. (`[application/src/main/java/com/callv2/drive/application/file/retrieve/list/FileListInput.javaR1-R11](diffhunk://#diff-7ee06a1aab9bc7d55955081385d9202315c1e52b9a959afdcfcc46bb961ec42eR1-R11)`)