### PR TITLE
Update AccessPermission references from SHARE to MANAGE

### DIFF
--- a/domain/src/main/java/com/callv2/drive/domain/acl/AccessPermission.java
+++ b/domain/src/main/java/com/callv2/drive/domain/acl/AccessPermission.java
@@ -1,7 +1,7 @@
 package com.callv2.drive.domain.acl;
 
 public enum AccessPermission implements Permission<AccessPermission> {
-    SHARE(0),
+    MANAGE(0),
     WRITE(1),
     READ(2);
 
@@ -24,7 +24,7 @@ public enum AccessPermission implements Permission<AccessPermission> {
     }
 
     public Boolean canShare() {
-        return this.level <= SHARE.level;
+        return this.level <= MANAGE.level;
     }
 
     public Boolean canWrite() {
@@ -40,7 +40,7 @@ public enum AccessPermission implements Permission<AccessPermission> {
     }
 
     public static AccessPermission mostPrivileged() {
-        return SHARE;
+        return MANAGE;
     }
 
     public Boolean allows(final AccessPermission permission) {

--- a/domain/src/main/java/com/callv2/drive/domain/acl/Acl.java
+++ b/domain/src/main/java/com/callv2/drive/domain/acl/Acl.java
@@ -169,7 +169,7 @@ public class Acl extends AggregateRoot<AclID> implements EventSource {
         }
 
         effectiveAccessPermission(revoker)
-                .filter(sp -> sp.allows(AccessPermission.SHARE))
+                .filter(sp -> sp.allows(AccessPermission.MANAGE))
                 .orElseThrow(() -> NotAllowedException.with(
                         "'granter' does not have share permission to revoke accessPermission",
                         "accessPermission level too low"));


### PR DESCRIPTION
This pull request updates the naming and semantics of the highest access permission in the ACL system, replacing the `SHARE` permission with `MANAGE`. All relevant methods and logic have been updated to reflect this change, ensuring that the most privileged permission is now called `MANAGE` and that permission checks use this new name.

**Access Permission Renaming and Logic Updates:**

* Renamed the highest access permission in the `AccessPermission` enum from `SHARE` to `MANAGE` in `AccessPermission.java`.
* Updated the `canShare()` method to check against `MANAGE` instead of `SHARE`.
* Changed the `mostPrivileged()` method to return `MANAGE` instead of `SHARE`.
* Updated permission checks in `Acl.java` to use `MANAGE` instead of `SHARE` when determining if a user can revoke access.