### PR TITLE
feat: implement PathResolutionApplicationService and integrate with f…

### DIFF
--- a/application/src/main/java/com/callv2/drive/application/folder/service/PathResolutionApplicationService.java
+++ b/application/src/main/java/com/callv2/drive/application/folder/service/PathResolutionApplicationService.java
@@ -1,0 +1,41 @@
+package com.callv2.drive.application.folder.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import com.callv2.drive.domain.folder.FolderGateway;
+import com.callv2.drive.domain.folder.entity.Folder;
+import com.callv2.drive.domain.member.MemberID;
+
+public class PathResolutionApplicationService {
+
+    private final FolderGateway folderGateway;
+
+    public PathResolutionApplicationService(final FolderGateway folderGateway) {
+        this.folderGateway = Objects.requireNonNull(folderGateway);
+    }
+
+    public List<Folder> resolvePath(final Folder folder, final MemberID actorId) {
+
+        Folder parentFolder = folder;
+        final List<Folder> pathFolders = new ArrayList<>(List.of(folder));
+
+        if (parentFolder.isRootFolder())
+            return pathFolders;
+
+        do {
+
+            parentFolder = folderGateway
+                    .findByIdWithMemberAccess(parentFolder.getVirtualParentFolder(actorId), actorId)
+                    .orElse(parentFolder);
+
+            pathFolders.add(parentFolder);
+
+        } while (!parentFolder.isRootFolder());
+
+        return pathFolders;
+
+    }
+
+}

--- a/application/src/main/java/com/callv2/drive/application/folder/usecase/retrieve/get/DefaultGetFolderUseCase.java
+++ b/application/src/main/java/com/callv2/drive/application/folder/usecase/retrieve/get/DefaultGetFolderUseCase.java
@@ -1,7 +1,9 @@
 package com.callv2.drive.application.folder.usecase.retrieve.get;
 
+import java.util.List;
 import java.util.Objects;
 
+import com.callv2.drive.application.folder.service.PathResolutionApplicationService;
 import com.callv2.drive.domain.exception.NotFoundException;
 import com.callv2.drive.domain.file.FileGateway;
 import com.callv2.drive.domain.folder.FolderGateway;
@@ -14,11 +16,15 @@ public class DefaultGetFolderUseCase extends GetFolderUseCase {
     private final FolderGateway folderGateway;
     private final FileGateway fileGateway;
 
+    private final PathResolutionApplicationService pathResolutionService;
+
     public DefaultGetFolderUseCase(
             final FolderGateway folderGateway,
-            final FileGateway fileGateway) {
+            final FileGateway fileGateway,
+            final PathResolutionApplicationService pathResolutionService) {
         this.folderGateway = Objects.requireNonNull(folderGateway);
         this.fileGateway = Objects.requireNonNull(fileGateway);
+        this.pathResolutionService = Objects.requireNonNull(pathResolutionService);
     }
 
     @Override
@@ -31,12 +37,16 @@ public class DefaultGetFolderUseCase extends GetFolderUseCase {
                 .findByIdWithMemberAccess(folderId, actorId)
                 .orElseThrow(() -> NotFoundException.with(Folder.class, input.folderId().toString()));
 
+        final List<Folder> pathFolders = pathResolutionService.resolvePath(folder, actorId);
+
         return GetFolderOutput
                 .from(
                         actorId,
                         folder,
+                        pathFolders,
                         folderGateway.findByParentFolderIdWithMemberAccess(folder.getId(), actorId),
                         fileGateway.findAllByFolder(folder.getId()));
+
     }
 
 }

--- a/application/src/main/java/com/callv2/drive/application/folder/usecase/retrieve/get/GetFolderOutput.java
+++ b/application/src/main/java/com/callv2/drive/application/folder/usecase/retrieve/get/GetFolderOutput.java
@@ -14,6 +14,7 @@ public record GetFolderOutput(
         String name,
         Boolean isRootFolder,
         UUID parentFolder,
+        List<GetFolderOutput.PathSegment> path,
         Set<GetFolderOutput.SubFolder> subFolders,
         Set<GetFolderOutput.File> files,
         UUID ownerId,
@@ -24,6 +25,7 @@ public record GetFolderOutput(
     public static GetFolderOutput from(
             final MemberID actor,
             final Folder folder,
+            final List<Folder> path,
             final Set<Folder> subFolders,
             final List<com.callv2.drive.domain.file.File> files) {
 
@@ -32,6 +34,10 @@ public record GetFolderOutput(
                 folder.getName().value(),
                 folder.isRootFolder(),
                 folder.getVirtualParentFolder(actor).getValue(),
+                path
+                        .stream()
+                        .map(GetFolderOutput.PathSegment::from)
+                        .collect(Collectors.toList()),
                 subFolders
                         .stream()
                         .map(GetFolderOutput.SubFolder::from)
@@ -44,6 +50,16 @@ public record GetFolderOutput(
                 folder.getCreatedAt(),
                 folder.getUpdatedAt(),
                 folder.getDeletedAt());
+    }
+
+    public static record PathSegment(UUID id, String name) {
+
+        public static GetFolderOutput.PathSegment from(final Folder folder) {
+            return new GetFolderOutput.PathSegment(
+                    folder.getId().getValue(),
+                    folder.getName().value());
+        }
+
     }
 
     public static record SubFolder(UUID id, String name) {

--- a/application/src/test/java/com/callv2/drive/application/folder/usecase/retrieve/get/DefaultGetFolderUseCaseTest.java
+++ b/application/src/test/java/com/callv2/drive/application/folder/usecase/retrieve/get/DefaultGetFolderUseCaseTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -19,6 +20,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.callv2.drive.application.folder.service.PathResolutionApplicationService;
 import com.callv2.drive.domain.exception.NotFoundException;
 import com.callv2.drive.domain.file.FileGateway;
 import com.callv2.drive.domain.folder.FolderGateway;
@@ -39,18 +41,23 @@ public class DefaultGetFolderUseCaseTest {
     @Mock
     FileGateway fileGateway;
 
+    @Mock
+    PathResolutionApplicationService pathResolutionService;
+
     @Test
     void givenAValidFolderId_whenCallsExecute_thenShouldReturnFolder() {
 
         final var ownerId = MemberID.of(UUID.randomUUID());
         final var actorId = ownerId;
 
+        final var expectedRootFolder = Folder.createRoot(ownerId);
+
         final var expectedFolderName = "folder";
         final var expectedFolder = Folder.create(
                 ownerId,
                 ownerId,
                 FolderName.of(expectedFolderName),
-                Folder.createRoot(ownerId));
+                expectedRootFolder);
 
         final var expectedSubFolder1 = Folder.create(
                 ownerId,
@@ -76,6 +83,9 @@ public class DefaultGetFolderUseCaseTest {
         when(folderGateway.findByParentFolderIdWithMemberAccess(expectedFolder.getId(), actorId))
                 .thenReturn(expectedSubFolders);
 
+        when(pathResolutionService.resolvePath(expectedFolder, actorId))
+                .thenReturn(List.of(expectedFolder, expectedRootFolder));
+
         final var input = GetFolderInput.with(expectedFolderId.getValue(), ownerId.getValue());
 
         final var actualOutput = assertDoesNotThrow(() -> useCase.execute(input));
@@ -84,6 +94,10 @@ public class DefaultGetFolderUseCaseTest {
         assertEquals(expectedFolderName, actualOutput.name());
         assertEquals(expectedFolder.getParentFolder().getValue(), actualOutput.parentFolder());
         assertEquals(expectedSubFolders.size(), actualOutput.subFolders().size());
+        assertEquals(expectedRootFolder.getId().getValue(), actualOutput.path().get(1).id());
+        assertEquals(expectedRootFolder.getName().value(), actualOutput.path().get(1).name());
+        assertEquals(expectedFolder.getId().getValue(), actualOutput.path().get(0).id());
+        assertEquals(expectedFolder.getName().value(), actualOutput.path().get(0).name());
         assertEquals(expectedCreatedAt, actualOutput.createdAt());
         assertEquals(expectedUpdatedAt, actualOutput.updatedAt());
         assertEquals(expectedDeletedAt, actualOutput.deletedAt());
@@ -93,6 +107,9 @@ public class DefaultGetFolderUseCaseTest {
 
         verify(folderGateway, times(1)).findByParentFolderIdWithMemberAccess(any(), any());
         verify(folderGateway, times(1)).findByParentFolderIdWithMemberAccess(eq(expectedFolder.getId()), eq(actorId));
+
+        verify(pathResolutionService, times(1)).resolvePath(any(), any());
+        verify(pathResolutionService, times(1)).resolvePath(eq(expectedFolder), eq(actorId));
 
     }
 
@@ -120,6 +137,8 @@ public class DefaultGetFolderUseCaseTest {
 
         verify(folderGateway, times(1)).findByIdWithMemberAccess(any(), any());
         verify(folderGateway, times(1)).findByIdWithMemberAccess(eq(expectedFolderId), eq(expectActorId));
+
+        verify(pathResolutionService, times(0)).resolvePath(any(), any());
 
     }
 

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/configuration/application/service/FolderApplicationServiceConfig.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/configuration/application/service/FolderApplicationServiceConfig.java
@@ -4,6 +4,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import com.callv2.drive.application.folder.service.FolderProvisioningApplicationService;
+import com.callv2.drive.application.folder.service.PathResolutionApplicationService;
 import com.callv2.drive.domain.acl.AclGateway;
 import com.callv2.drive.domain.event.EventDispatcher;
 import com.callv2.drive.domain.folder.FolderGateway;
@@ -30,6 +31,11 @@ public class FolderApplicationServiceConfig {
                 eventDispatcher,
                 folderGateway,
                 aclGateway);
+    }
+
+    @Bean
+    PathResolutionApplicationService pathResolutionApplicationService() {
+        return new PathResolutionApplicationService(folderGateway);
     }
 
 }

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/configuration/application/usecase/FolderUseCaseConfig.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/configuration/application/usecase/FolderUseCaseConfig.java
@@ -4,6 +4,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import com.callv2.drive.application.folder.service.FolderProvisioningApplicationService;
+import com.callv2.drive.application.folder.service.PathResolutionApplicationService;
 import com.callv2.drive.application.folder.usecase.create.CreateFolderUseCase;
 import com.callv2.drive.application.folder.usecase.create.DefaultCreateFolderUseCase;
 import com.callv2.drive.application.folder.usecase.delete.DefaultDeleteFolderUseCase;
@@ -41,6 +42,7 @@ public class FolderUseCaseConfig {
     private final EventDispatcher eventDispatcher;
 
     private final FolderProvisioningApplicationService folderProvisioningApplicationService;
+    private final PathResolutionApplicationService pathResolutionService;
 
     public FolderUseCaseConfig(
             final AclGateway aclGateway,
@@ -48,13 +50,15 @@ public class FolderUseCaseConfig {
             final FileGateway fileGateway,
             final MemberGateway memberGateway,
             final EventDispatcher eventDispatcher,
-            final FolderProvisioningApplicationService folderProvisioningApplicationService) {
+            final FolderProvisioningApplicationService folderProvisioningApplicationService,
+            final PathResolutionApplicationService pathResolutionService) {
         this.aclGateway = aclGateway;
         this.folderGateway = folderGateway;
         this.fileGateway = fileGateway;
         this.memberGateway = memberGateway;
         this.eventDispatcher = eventDispatcher;
         this.folderProvisioningApplicationService = folderProvisioningApplicationService;
+        this.pathResolutionService = pathResolutionService;
     }
 
     @Bean
@@ -72,7 +76,7 @@ public class FolderUseCaseConfig {
 
     @Bean
     GetFolderUseCase getFolderUseCase() {
-        return new DefaultGetFolderUseCase(folderGateway, fileGateway);
+        return new DefaultGetFolderUseCase(folderGateway, fileGateway, pathResolutionService);
     }
 
     @Bean

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/folder/model/FolderPath.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/folder/model/FolderPath.java
@@ -1,0 +1,11 @@
+package com.callv2.drive.infrastructure.folder.model;
+
+import java.util.List;
+import java.util.UUID;
+
+public record FolderPath(List<Segment> segments) {
+
+    public record Segment(UUID id, String name) {
+    }
+
+}

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/folder/model/GetFolderResponse.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/folder/model/GetFolderResponse.java
@@ -9,6 +9,7 @@ public record GetFolderResponse(
         String name,
         Boolean rootFolder,
         UUID parentFolder,
+        FolderPath path,
         Set<GetFolderResponse.SubFolder> subFolders,
         Set<GetFolderResponse.File> files,
         UUID ownerId,

--- a/infrastructure/src/main/java/com/callv2/drive/infrastructure/folder/presenter/FolderPresenter.java
+++ b/infrastructure/src/main/java/com/callv2/drive/infrastructure/folder/presenter/FolderPresenter.java
@@ -1,5 +1,9 @@
 package com.callv2.drive.infrastructure.folder.presenter;
 
+import static java.util.Objects.isNull;
+
+import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import com.callv2.drive.application.folder.usecase.create.CreateFolderOutput;
@@ -9,6 +13,7 @@ import com.callv2.drive.application.folder.usecase.retrieve.list.FolderListOutpu
 import com.callv2.drive.application.folder.usecase.sharing.retrieve.list.FolderSharingListOutput;
 import com.callv2.drive.infrastructure.folder.model.CreateFolderResponse;
 import com.callv2.drive.infrastructure.folder.model.FolderListResponse;
+import com.callv2.drive.infrastructure.folder.model.FolderPath;
 import com.callv2.drive.infrastructure.folder.model.FolderSharingListResponse;
 import com.callv2.drive.infrastructure.folder.model.GetFolderResponse;
 
@@ -24,6 +29,7 @@ public interface FolderPresenter {
                 output.name(),
                 output.isRootFolder(),
                 output.parentFolder(),
+                present(output.path()),
                 output.subFolders().stream()
                         .map(FolderPresenter::present)
                         .collect(Collectors.toSet()),
@@ -55,6 +61,7 @@ public interface FolderPresenter {
                 output.name(),
                 true,
                 null,
+                present(present(output.id(), output.name())),
                 output
                         .subFolders()
                         .stream()
@@ -105,6 +112,32 @@ public interface FolderPresenter {
                 output.sharedBy(),
                 output.accessPermission(),
                 output.createdAt());
+    }
+
+    static FolderPath present(final List<GetFolderOutput.PathSegment> pathItems) {
+
+        if (isNull(pathItems))
+            return new FolderPath(List.of());
+
+        final var segments = pathItems
+                .stream()
+                .map(pathItem -> present(pathItem.id(), pathItem.name()))
+                .collect(Collectors.toList());
+
+        return new FolderPath(segments);
+    }
+
+    static FolderPath present(final FolderPath.Segment segment) {
+
+        if (isNull(segment))
+            return new FolderPath(List.of());
+
+        return new FolderPath(List.of(segment));
+
+    }
+
+    static FolderPath.Segment present(final UUID id, final String name) {
+        return new FolderPath.Segment(id, name);
     }
 
 }


### PR DESCRIPTION
This pull request introduces a new feature to expose the full folder path (as a list of folder segments) in the folder retrieval use case and its API response. The changes include adding a path resolution service, updating the use case and output records to include the path, and adapting the presenter and response models to support and display the folder path.

**Path Resolution and Use Case Integration:**

* Added a new `PathResolutionApplicationService` that resolves the full path of a folder up to the root, considering member access.
* Updated `DefaultGetFolderUseCase` to use `PathResolutionApplicationService` and include the resolved path in its output. [[1]](diffhunk://#diff-83d553b0e1c64d47b966ffcd6e03a2e2ca6bce6fc01da6727862ec9340e5d9d7R3-R6) [[2]](diffhunk://#diff-83d553b0e1c64d47b966ffcd6e03a2e2ca6bce6fc01da6727862ec9340e5d9d7R19-R27) [[3]](diffhunk://#diff-83d553b0e1c64d47b966ffcd6e03a2e2ca6bce6fc01da6727862ec9340e5d9d7R40-R49)
* Modified `GetFolderOutput` to include a list of `PathSegment` records representing the folder path. [[1]](diffhunk://#diff-d5c3b5264cf0e0260db1361dfaf7f12bac0057ff0be80b38b35302b513f657b3R17) [[2]](diffhunk://#diff-d5c3b5264cf0e0260db1361dfaf7f12bac0057ff0be80b38b35302b513f657b3R28) [[3]](diffhunk://#diff-d5c3b5264cf0e0260db1361dfaf7f12bac0057ff0be80b38b35302b513f657b3R37-R40) [[4]](diffhunk://#diff-d5c3b5264cf0e0260db1361dfaf7f12bac0057ff0be80b38b35302b513f657b3R55-R64)

**API and Presentation Layer Updates:**

* Added `FolderPath` and `FolderPath.Segment` records to the infrastructure layer for API responses.
* Updated `GetFolderResponse` to include the folder path.
* Enhanced `FolderPresenter` to map domain path segments to API response format, including utility methods for path presentation. [[1]](diffhunk://#diff-91dfce2c27679528c8313da37c52826a5d14169783ec9f7fdff5660abe01e079R3-R6) [[2]](diffhunk://#diff-91dfce2c27679528c8313da37c52826a5d14169783ec9f7fdff5660abe01e079R16) [[3]](diffhunk://#diff-91dfce2c27679528c8313da37c52826a5d14169783ec9f7fdff5660abe01e079R32) [[4]](diffhunk://#diff-91dfce2c27679528c8313da37c52826a5d14169783ec9f7fdff5660abe01e079R64) [[5]](diffhunk://#diff-91dfce2c27679528c8313da37c52826a5d14169783ec9f7fdff5660abe01e079R117-R142)

**Configuration Changes:**

* Registered `PathResolutionApplicationService` as a Spring bean and injected it into the relevant use case and configuration classes. [[1]](diffhunk://#diff-113eaf008e429dae38e008187e2b19597a52f6cb71f25b8e47321f15d4fee292R7) [[2]](diffhunk://#diff-113eaf008e429dae38e008187e2b19597a52f6cb71f25b8e47321f15d4fee292R36-R40) [[3]](diffhunk://#diff-1a8b44c37b7c2d452748d3f9ffb29026b0257f34db41df8a8b92b3d776e23578R7) [[4]](diffhunk://#diff-1a8b44c37b7c2d452748d3f9ffb29026b0257f34db41df8a8b92b3d776e23578R45-R61) [[5]](diffhunk://#diff-1a8b44c37b7c2d452748d3f9ffb29026b0257f34db41df8a8b92b3d776e23578L75-R79)

These changes collectively enable clients to retrieve the full navigational path for any folder, supporting features such as breadcrumb navigation in the UI.